### PR TITLE
fix(auth): session cookie secure flag on HTTP LAN deployment

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -67,7 +67,7 @@ module Authentication
           value: session.id,
           httponly: true,
           same_site: :strict,
-          secure: Rails.env.production?,
+          secure: request.ssl?,
           expires: 30.days.from_now
         }
       end


### PR DESCRIPTION
## Bug

After PR #24 went out, login failed silently: POST /session authenticated fine (server log showed 302 to /boards), but the very next request bounced back to /session/new. Classic cookie-not-being-sent loop.

## Root cause

`app/controllers/concerns/authentication.rb:70` was setting the session cookie with `secure: Rails.env.production?`. LAN deployment runs plain HTTP (force_ssl=false, commit ea3b0fd), so the browser accepted the Set-Cookie header but then refused to send it back on subsequent HTTP requests — `Secure` cookies only go over HTTPS.

## Fix

`secure: request.ssl?` — secure-flag follows the actual transport of the request, so HTTPS-fronted deployments still get the flag, plain-HTTP LAN deployments don't. Same pattern Rails uses for `force_ssl` and `default_url_options`.

## Verification

End-to-end through Playwright:
- Before: POST /session → 302 /boards, then GET /boards → 302 /session/new (loop)
- After: POST /session → 302 /boards/1, then GET /boards/1 → 200, full kanban renders, realtime connects.

## Also observed (not fixed here)

One login POST took 11.5s of ActiveRecord time — likely an N+1 on first-user-ever boot (possibly `OpenclawMemorySearchHealthService` or `CostSnapshot` lookup). Separate issue, not blocking.
