### PR TITLE
fix(encryption): AR::Encryption keys from ENV + rescue Configuration error

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,7 @@ class User < ApplicationRecord
   %i[ai_api_key telegram_bot_token openclaw_gateway_token openclaw_hooks_token].each do |encrypted_attr|
     define_method(encrypted_attr) do
       super()
-    rescue ActiveRecord::Encryption::Errors::Decryption, ActiveRecord::Encryption::Errors::EncryptedContentIntegrity
+    rescue ActiveRecord::Encryption::Errors::Decryption, ActiveRecord::Encryption::Errors::EncryptedContentIntegrity, ActiveRecord::Encryption::Errors::Configuration
       nil
     end
   end

--- a/config/initializers/active_record_encryption.rb
+++ b/config/initializers/active_record_encryption.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Wire ActiveRecord::Encryption keys from ENV in production deploys that
+# don't use Rails credentials (no master.key on disk). Keys are generated
+# at first deploy and persisted in /etc/clawtrol/clawtrol.env. Rotating any
+# of these makes existing encrypted columns undecryptable — the rescue in
+# app/models/user.rb returns nil for those fields so the app keeps serving.
+%i[primary_key deterministic_key key_derivation_salt].each do |key|
+  env_name = "ACTIVE_RECORD_ENCRYPTION_#{key.to_s.upcase}"
+  value = ENV[env_name]
+  Rails.application.config.active_record.encryption.public_send("#{key}=", value) if value.present?
+end


### PR DESCRIPTION
## Why

Discovered during post-audit recovery: the production deployment had always pointed at an empty `clawdeck_production` DB (port 15432) instead of the real DB with 5 users + 427 tasks that lives in `clawdeck_development` on the `dashboard-postgres` container (port 5432). After repointing DATABASE_URL at the live data, rendering `/boards` 500'd with:

```
ActiveRecord::Encryption::Errors::Configuration:
  Missing Active Record encryption credential: active_record_encryption.primary_key
```

Keys used to live in `config/credentials.yml.enc`, which was deleted during audit Phase 3.4 cleanup because `config/master.key` was missing from the start (making the file unreadable anyway). The deployment's historical encryption keys aren't recoverable — no copy survived on disk.

## What

1. **`config/initializers/active_record_encryption.rb`** (new) — reads the three keys from env vars:
   - `ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY`
   - `ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY`
   - `ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT`

   Only assigns when the env var is present, so development/test environments that configure keys inline (e.g. `config/environments/test.rb`) keep working unchanged.

2. **`app/models/user.rb`** — existing rescue for encrypted-attribute readers now catches `ActiveRecord::Encryption::Errors::Configuration` in addition to `Decryption` + `EncryptedContentIntegrity`. Missing-key state now degrades to `nil` readers instead of 500-ing view rendering.

## Operator checklist

1. Generate 3 hex keys on the deploy host: `openssl rand -hex 16` × 3.
2. Append to `/etc/clawtrol/clawtrol.env` (or equivalent secret store):
   ```
   ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=...
   ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=...
   ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=...
   ```
3. Restart the Rails service.
4. Existing encrypted column values (`users.ai_api_key`, `telegram_bot_token`, `openclaw_gateway_token`, `openclaw_hooks_token`) will be un-decryptable under the new keys. Rescue returns `nil`; re-enter the 4 fields in settings UI.

## Verification

- Playwright end-to-end after deploy: `/boards/1` renders "ALL - ClawTrol" with 119 tasks aggregated across 8 sub-boards; no 500.
- `ruby -c` clean on both edited files.
- Existing bcrypt-authenticated login (`Clawdeck2026!`) works end-to-end.
