### PR TITLE
chore(cleanup): remove dead audit-era infra + correct AUDIT topology note

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,9 @@ services:
     
   db:
     image: postgres:16-alpine
-    ports:
-      - "127.0.0.1:15432:5432"
+    # Not used in the production deployment: Rails runs on the host
+    # against the dashboard-postgres container on 127.0.0.1:5432
+    # (see docs/audit/2026-04-17/AUDIT.md correction note).
     volumes:
       - pgdata:/var/lib/postgresql/data
     environment:

--- a/docs/audit/2026-04-17/AUDIT.md
+++ b/docs/audit/2026-04-17/AUDIT.md
@@ -10,6 +10,10 @@
 
 ---
 
+> **2026-04-18 correction (post-merge of PR #26):** the System Overview, Evidence Index, and FIX PROMPTS sections below describe  on  as the deployment database. That was **wrong** — it was an empty container the repo's  happened to describe. The real production data has always lived in  on host port 5432 via the  container (shared with the personaldashboard app, credentials in ).  was repointed on 2026-04-18; the  Postgres role and the  container created during audit remediation are now dead infrastructure and are being removed in PR-TBD. All findings below remain correct; only the DB host/name was wrong.
+
+---
+
 ## Hard Stops
 
 **No H-class conditions found.** The audit ran the full §1.4 checklist:


### PR DESCRIPTION
## Summary

Post-audit cleanup of dead infrastructure discovered after PR #26 when we realized the real production DB is `dashboard-postgres` / `clawdeck_development`, not the empty `clawdeck-db-1` / `clawdeck_production` that PRs #24-#26 assumed.

## Changes

**`docker-compose.yml`** — removed the `127.0.0.1:15432:5432` port binding I added in Phase 1.2 of the audit. Added a comment explaining that the file describes a deployment topology that this host does **not** use (Rails on the host, Postgres via `dashboard-postgres`). Prevents future operators from bringing the empty container back up.

**`docs/audit/2026-04-17/AUDIT.md`** — added a 2026-04-18 correction block above the Hard Stops section noting the DB-host/name error in the System Overview. All findings stand; only the topology was wrong.

**`db/development.sqlite3`** — deleted empty 0-byte file. Unused in this deployment.

## Out-of-git cleanup performed on the VM alongside this commit

- `docker compose down -v` removed:
  - `clawdeck-db-1` container
  - `clawdeck_pgdata` volume
  - `clawdeck_clawdeck-network` network
- The `clawtrol_app` Postgres role that Phase 4.1 of the audit created was scoped to the `clawdeck-db-1` instance, so it's gone with the container.

## Verification

- `clawtrol.service` stayed up throughout — operates against the real `dashboard-postgres` DB, unaffected by `clawdeck-db-1` removal.
- `curl /up` returns 200 post-cleanup.
