### PR TITLE
feat(ops): add Sentry error tracking (no-op without SENTRY_DSN)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,7 @@ gem "diffy"
 
 gem "chartkick", "~> 5.2"
 gem "groupdate", "~> 6.7"
+
+# Error tracking (no-op unless SENTRY_DSN is set)
+gem "sentry-ruby", "~> 5.17"
+gem "sentry-rails", "~> 5.17"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,6 +382,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    sentry-rails (5.28.1)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.28.1)
+    sentry-ruby (5.28.1)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
@@ -489,6 +495,8 @@ DEPENDENCIES
   redcarpet
   rubocop-rails-omakase
   selenium-webdriver
+  sentry-rails (~> 5.17)
+  sentry-ruby (~> 5.17)
   solid_cable
   solid_cache
   solid_queue

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Sentry is enabled only when SENTRY_DSN is configured. Without a DSN, the
+# gem is a no-op so the app stays free of error-tracker noise in dev boxes
+# and ephemeral test runs.
+if ENV["SENTRY_DSN"].present?
+  Sentry.init do |config|
+    config.dsn = ENV["SENTRY_DSN"]
+    config.breadcrumbs_logger = %i[active_support_logger http_logger]
+    config.environment = Rails.env
+    config.release = ENV.fetch("SENTRY_RELEASE") { ENV.fetch("GIT_SHA", "unknown") }
+    config.traces_sample_rate = ENV.fetch("SENTRY_TRACES_SAMPLE_RATE", "0.05").to_f
+    config.send_default_pii = false
+
+    # Filter known-benign noise
+    config.excluded_exceptions += %w[
+      ActionController::RoutingError
+      ActiveRecord::RecordNotFound
+      ActionController::InvalidAuthenticityToken
+    ]
+
+    # Scrub request params that may contain tokens
+    config.before_send = lambda do |event, _hint|
+      scrubbed = %w[password password_confirmation token api_token bearer
+                    authorization secret hooks_token openclaw_gateway_token
+                    openclaw_hooks_token ai_api_key telegram_bot_token]
+      if event.request&.data.is_a?(Hash)
+        scrubbed.each { |k| event.request.data[k] &&= "[FILTERED]" if event.request.data.key?(k) }
+      end
+      event
+    end
+  end
+end


### PR DESCRIPTION
## Why

Audit Domain 4 (Infrastructure) and Domain 12 (What's Missing But Expected) both flagged the absence of any error-tracking / APM as a P1 gap. Background jobs that fail, view rendering errors outside the happy path, and production-only 500s all go unobserved — whoever operates this app finds out via "Gonzalo says it looks broken."

## What

- `Gemfile`: add `sentry-ruby ~> 5.17` and `sentry-rails ~> 5.17`.
- `config/initializers/sentry.rb`: initialize Sentry **only when `SENTRY_DSN` is set**. Without a DSN the gem is a runtime no-op — dev boxes, CI, and deployments that don't want Sentry pay zero cost.

### Config the initializer honors

| ENV var | default | effect |
|---|---|---|
| `SENTRY_DSN` | *(unset)* | when blank, Sentry is inactive |
| `SENTRY_RELEASE` | falls back to `GIT_SHA`, then `"unknown"` | release tagging |
| `SENTRY_TRACES_SAMPLE_RATE` | `0.05` (5%) | perf-trace sample rate |

### Noise exclusions

- `ActionController::RoutingError`
- `ActiveRecord::RecordNotFound`
- `ActionController::InvalidAuthenticityToken`

### Scrubbed request-body keys before send

`password`, `password_confirmation`, `token`, `api_token`, `bearer`, `authorization`, `secret`, `hooks_token`, `openclaw_gateway_token`, `openclaw_hooks_token`, `ai_api_key`, `telegram_bot_token`.

## How to activate

Pick one after merge:
1. Self-hosted GlitchTip (free, drop-in compatible) — create a project, add the DSN to `/etc/clawtrol/clawtrol.env`, restart.
2. Sentry free tier (5k events/month) — same flow.
3. Leave `SENTRY_DSN` unset and nothing changes.
