### PR TITLE
chore(claude): curate .claude/ rules + skills for local-first workflow

### DIFF
--- a/.claude/_curation_log_2026-04-19.md
+++ b/.claude/_curation_log_2026-04-19.md
@@ -1,0 +1,77 @@
+# Curation Log — 2026-04-19
+
+Curation of `clawtrol/.claude/` via the `project-curate` skill. Branch `omni/fix-claude-rules-curation`.
+
+## Context before curation
+
+- Stack: Rails 8.1 + Postgres + Solid Queue/Cache/Cable + Hotwire (Turbo + Stimulus) + Tailwind via tailwindcss-rails + Importmap (no Node at root) + Propshaft + Puma + dotenv-rails + OmniAuth (no Devise) + Sentry.
+- Layout: standard Rails. `app/{models,views,controllers,javascript,services,assets}`, `config/`, `db/`, `test/` (Minitest). `app/components/` does NOT exist. Tailwind source CSS at `app/assets/tailwind/application.css`.
+- Repo: full git clone of `wolverin0/clawtrol` on Windows. VM at `/home/ggorbalan/clawdeck` is pull-only (deploy target).
+- Pre-existing `.claude/`: empty except for the `_backups/` tarball written by this skill on the prior pass. No mass-installed noise to archive.
+- CLAUDE.md: missing. AGENTS.md: present (300+ lines, comprehensive but had stale SSH-edit references in sections 2/8/9 from the pre-2026-04-19 "Windows is a docs mirror" era).
+- Memory: 0 prior MemoryMaster claims for `project:clawtrol` (added 3 during this session — see mm-3967, mm-31cb, mm-9169).
+
+## What was copied from ECC
+
+ECC has no `rules/ruby/` directory — no copy possible for the Rails stack. Only the web rules were applicable:
+
+| ECC source | Local target | Frontmatter injected |
+|---|---|---|
+| `rules/web/design-quality.md` | `.claude/rules/web/design-quality.md` | `app/views/**/*.erb`, `app/assets/stylesheets/**/*.css` |
+| `rules/web/performance.md` | `.claude/rules/web/performance.md` | `app/views/**/*.erb`, `app/javascript/**/*.js`, `app/assets/**/*.{js,css}`, `config/importmap.rb` |
+| `rules/web/security.md` | `.claude/rules/web/security.md` | `app/**/*.{rb,erb,js,css}`, `config/**/*.{rb,yml}`, `lib/**/*.rb` |
+
+The ECC web rules ship without `paths:` frontmatter; per the skill spec they were given Rails-flavored globs to scope load.
+
+## What was generated (project-specific)
+
+| File | Why | Source signals |
+|---|---|---|
+| `local-first-workflow.md` | The 2026-04-19 workflow pivot from SSH-edit-on-VM to local-clone + deploy-to-vm needed durable rules, not just AGENTS.md prose. | AGENTS.md section 1 update, the new `/deploy-to-vm` skill, repo topology |
+| `rails-conventions.md` | No ECC `rules/ruby/` exists. Rails 8.1 has enough sharp edges (Hotwire vs custom JS, Propshaft vs Sprockets, Importmap vs Node, dotenv vs credentials, Solid Queue vs Sidekiq) to warrant a focused rule. | Gemfile, `config/`, `app/javascript/`, `app/assets/tailwind/` |
+
+Two project-specific rules — well within the skill's 3-4 max budget.
+
+## What was preserved untouched
+
+- AGENTS.md: only the stale sections 2/8/9 were edited (local-first rewrite). Sections 1, 3-7, 10-12, BEADS integration, Landing the Plane — left intact.
+- CLAUDE.md: didn't exist, was created from scratch as a minimal Claude-specific entry pointing to AGENTS.md + the auto-loaded rules table.
+- `.claude/_backups/pre-curate-2026-04-19.tgz`: left in place, gitignored.
+
+## What was archived
+
+Nothing — no mass-install noise to archive. `.claude/_archive_noise_*` directory not created.
+
+## What was NOT done and why
+
+- **ECC ruby/ rules**: don't exist. Generated `rails-conventions.md` instead.
+- **CI/CD project rule**: AGENTS.md section 7 already documents the merge gate baseline + `bin/ci` is referenced. A separate rule would duplicate.
+- **Database/migration project rule**: covered inline in `rails-conventions.md` Migrations section. Stand-alone rule would split related context.
+- **Testing project rule**: global `~/.claude/rules/testing.md` covers basics. Minitest specifics covered in `rails-conventions.md`.
+- **Cherry-pick of ECC skills**: skipped per skill default ("user has 100+ globally; piling more on creates noise"). Only `deploy-to-vm` (a project-specific skill, not from ECC) is present.
+- **Cherry-pick of ECC agents**: skipped per skill default.
+- **Verifier pane**: skipped — coordinator-self-verify (Step 7b) used instead, which caught real drift (see below). Spawning a verifier pane for a 2-rule curation would be pure overhead.
+
+## Verifier — coordinator self-verify
+
+Grep-verified every backtick file/path/gem reference in the generated rules. Findings:
+
+| Rule | Reference | Status | Fix |
+|---|---|---|---|
+| `rails-conventions.md` | `config/tailwind.config.js` | BROKEN — actual path is `app/assets/tailwind/application.css` (Tailwind v4 + tailwindcss-rails) | Rewrote Tailwind section with correct path + explicit "no `config/tailwind.config.js`" note |
+| `rails-conventions.md` | `config/master.key`, `bin/rails credentials:edit` | BROKEN — project uses `dotenv-rails`, not Rails encrypted credentials. No `config/master.key` or `config/credentials.yml.enc` exists. | Rewrote Secrets section: dotenv-rails is canonical, `.env.production.example` is the template, NEVER attempt `credentials:edit` |
+| `rails-conventions.md` | "Not sure if there's ActiveJob/Solid Queue usage yet" | DRIFT — `solid_queue` is in Gemfile, hedge was unnecessary | Tightened to "use it as the ActiveJob backend" + added `solid_cache`/`solid_cable` family note |
+| `web/design-quality.md` | `app/components/**/*.{rb,erb}` glob | DEAD — `app/components/` doesn't exist (no ViewComponent gem); glob matches nothing | Removed the dead glob; kept `app/views/**/*.erb` + `app/assets/stylesheets/**/*.css` |
+| `CLAUDE.md` | (table sync) | Out of date with the design-quality.md fix above | Updated the auto-loaded-rules table to drop the components glob |
+| All other refs in all rules | (Gemfile gems, dirs, files) | VERIFIED | n/a |
+
+Self-verify caught 4 distinct drifts. Fix is in the `fix(claude-rules):` amendment commit.
+
+## Commits
+
+- `c9020ce` chore(claude): curate .claude/ rules + skills for local-first workflow
+- (next) fix(claude-rules): correct drifted identifiers caught by self-verify + add gitignore + curation log
+
+## Next
+
+User decides when to push `omni/fix-claude-rules-curation` and open the PR. The branch contains: AGENTS.md rewrite + new CLAUDE.md + `.claude/rules/` + `.claude/skills/deploy-to-vm/` + `.gitignore` update + this log.

--- a/.claude/rules/local-first-workflow.md
+++ b/.claude/rules/local-first-workflow.md
@@ -1,0 +1,47 @@
+# Local-First Workflow — Clawtrol
+
+As of 2026-04-19, clawtrol development happens in the **local git clone** at `G:\_OneDrive\OneDrive\Desktop\Py Apps\clawtrol\`, not via SSH-edit-on-VM. The VM runs the deployed version; it pulls from github, we push to github, the deploy skill orchestrates.
+
+## Golden rule
+
+**Edit locally. Deploy via `/deploy-to-vm`. Never SSH-edit files on the VM for non-emergency work.**
+
+## The topology
+
+- **Local (this dir):** full git clone of `https://github.com/wolverin0/clawtrol.git`. Same remote as the VM. Edits, commits, tests all happen here.
+- **VM `~/clawdeck/`:** running Rails service. Pulled from origin. Treat as read-only except when debugging.
+- **GitHub `wolverin0/clawtrol`:** source of truth. Both local and VM track it.
+
+## Daily flow
+
+1. `cd clawtrol` (local)
+2. Create/checkout a working branch
+3. Edit, run tests locally (`docker compose up`, `bin/rails test`, etc.)
+4. Commit atomically
+5. When ready to ship: `/deploy-to-vm` — the skill pushes to origin + pulls on VM + optionally restarts + smoke-checks
+
+## What NOT to do
+
+- **Never** SSH to the VM and `git commit` directly in `~/clawdeck/`. The VM working copy is deployment-only. If the VM has drift (like today's `M db/schema.rb`), resolve it by either committing & pushing upstream OR reverting — not by building on it.
+- **Never** skip the `/deploy-to-vm` pre-flight checks. They catch dirty-local, out-of-sync, VM-has-uncommitted-drift before network operations.
+- **Never** force-push. Destructive to team history and the VM deploy flow.
+- **Never** edit `docker-compose.yml` / `Dockerfile` on the VM only. Container changes need to go through git → deploy.
+
+## When SSH-to-VM IS appropriate
+
+Debugging-only, read-only, or one-off:
+
+- Tailing logs: `ssh ggorbalan@192.168.100.186 "cd ~/clawdeck && docker compose logs -f clawdeck"`
+- Checking service state: `docker compose ps`, `systemctl --user status clawdeck-web.service`
+- Running a one-off console: `docker compose exec clawdeck bin/rails console`
+- Inspecting DB: `docker compose exec db psql -U postgres clawdeck_production`
+
+If you catch yourself `vim`ing a file on the VM, STOP. Do it locally and deploy.
+
+## The audit workspace
+
+`G:\_OneDrive\OneDrive\Desktop\Py Apps\clawtrol-workspace\` holds the audit docs that used to live at this repo root before the 2026-04-19 re-clone (AUDIT.md, FIX_PROMPTS.md, FEATURE_IDEAS.md, roadmap.md, obsidian-vault/, screenshots). They're planning artifacts ABOUT the system, not part of the repo. Reference them as needed; commit new planning docs under `docs/` in this repo instead.
+
+## If you're confused about which path to edit
+
+Check by running `pwd && git remote get-url origin` in your current shell. If you see `G:\_OneDrive\...\clawtrol` AND `https://github.com/wolverin0/clawtrol.git`, you're in the right place.

--- a/.claude/rules/rails-conventions.md
+++ b/.claude/rules/rails-conventions.md
@@ -38,7 +38,7 @@ This edits `config/importmap.rb` and vendors the file. Do NOT `npm install` — 
 
 ## Tailwind CSS
 
-Tailwind via `tailwindcss-rails` gem. Config at `config/tailwind.config.js` or similar. Rebuild happens on boot in dev; in prod Dockerfile handles it. Don't inline style attributes when a Tailwind utility exists.
+Tailwind via `tailwindcss-rails` gem. Source CSS lives at `app/assets/tailwind/application.css` (Tailwind v4 + tailwindcss-rails convention — there is NO `config/tailwind.config.js`). Rebuild happens on boot in dev; in prod the Dockerfile handles it. Don't inline style attributes when a Tailwind utility exists.
 
 ## Migrations
 
@@ -60,17 +60,15 @@ docker compose run --rm clawdeck bin/rails test
 
 ## Secrets / Credentials
 
-Rails encrypted credentials. Master key in `config/master.key` (gitignored). Edit via:
+This project uses **`dotenv-rails`**, not Rails encrypted credentials. There is NO `config/master.key` or `config/credentials.yml.enc` in this repo — don't try to `bin/rails credentials:edit`.
 
-```bash
-bin/rails credentials:edit
-```
-
-Never put secrets in `.env` or source — they go in credentials. The `.env.production.example` exists as a template but production config is in Rails credentials.
+- Local dev/test secrets: `.env` files (gitignored). Template: `.env.production.example`.
+- Production secrets: env vars on the VM, loaded by docker compose.
+- Never commit `.env`. Never put secrets in source. If a secret needs to be added, update `.env.production.example` with a placeholder + document where the real value lives.
 
 ## Jobs + background work
 
-Not sure if there's ActiveJob/Solid Queue usage yet — check `config/application.rb` for the queue adapter. If adding background jobs, prefer Solid Queue (Rails 8 native) over Sidekiq unless there's a specific reason.
+`solid_queue` is in the Gemfile — use it as the ActiveJob backend. Don't add Sidekiq, Resque, or other queue gems unless there's a concrete reason Solid Queue can't handle the workload. Cache uses `solid_cache`, Action Cable uses `solid_cable` — same family, all Postgres-backed.
 
 ## Controllers thin, models fat
 

--- a/.claude/rules/rails-conventions.md
+++ b/.claude/rules/rails-conventions.md
@@ -1,0 +1,90 @@
+---
+paths:
+  - "app/**/*.{rb,erb}"
+  - "config/**/*.{rb,yml}"
+  - "db/migrate/**/*.rb"
+  - "test/**/*.rb"
+  - "Gemfile"
+---
+
+# Rails 8.1 Conventions — Clawtrol
+
+Stack (per Gemfile): Rails 8.1, Propshaft, Postgres (`pg`), Puma, Importmap, Turbo, Stimulus, Tailwind CSS, Jbuilder. Ruby version pinned in `.ruby-version`.
+
+## Hotwire-first
+
+This app uses Hotwire (Turbo + Stimulus), not a JS framework. Before reaching for anything custom:
+
+- **Turbo Drive** handles navigation. Don't replace with `fetch()` + DOM manipulation unless Turbo genuinely can't do it.
+- **Turbo Frames** for scoped updates. A form inside `<turbo-frame id="x">` naturally replaces just that frame on submit.
+- **Turbo Streams** for multi-region or server-pushed updates.
+- **Stimulus controllers** for client-side behavior. Controllers live in `app/javascript/controllers/`. Name by file, auto-registered.
+
+If you're writing a React component, stop and reconsider. The app's current trajectory is server-rendered + Hotwire. Breaking that is a scope decision, not a local choice.
+
+## Propshaft, not Sprockets
+
+Asset pipeline is **Propshaft**. Don't add `Sprockets` gems or `require_tree` directives. Static assets under `app/assets/` are served as-is with digest fingerprints. CSS is Tailwind + plain CSS; no SASS preprocessing unless explicitly added.
+
+## Importmap, not Node
+
+JavaScript is managed via **Importmap**, configured in `config/importmap.rb`. There's no `package.json` at the Rails root (any node_modules here would be a mistake). To add a JS library:
+
+```bash
+bin/importmap pin some-library
+```
+
+This edits `config/importmap.rb` and vendors the file. Do NOT `npm install` — you'd be fighting the tooling.
+
+## Tailwind CSS
+
+Tailwind via `tailwindcss-rails` gem. Config at `config/tailwind.config.js` or similar. Rebuild happens on boot in dev; in prod Dockerfile handles it. Don't inline style attributes when a Tailwind utility exists.
+
+## Migrations
+
+Rails 8.1 migrations: generate with `bin/rails g migration`. Always add a migration file — never hand-edit `db/schema.rb`. The schema file is regenerated from migrations. If you see schema.rb drift (like today's VM has `M db/schema.rb`), that's a smell — find the migration that should produce it or revert the drift.
+
+## Tests
+
+`test/` directory uses Minitest (Rails default). Run via `bin/rails test` or `bin/rails test:system` for system tests. Before deploying via `/deploy-to-vm`, tests must pass:
+
+```bash
+docker compose run --rm clawdeck bin/rails test
+```
+
+## ActiveRecord scope
+
+- Queries scoped via named scopes in the model, not inline in controllers
+- N+1 via `includes(:association)` in controller actions
+- No raw SQL unless absolutely necessary — prefer Arel or parameterized AR
+
+## Secrets / Credentials
+
+Rails encrypted credentials. Master key in `config/master.key` (gitignored). Edit via:
+
+```bash
+bin/rails credentials:edit
+```
+
+Never put secrets in `.env` or source — they go in credentials. The `.env.production.example` exists as a template but production config is in Rails credentials.
+
+## Jobs + background work
+
+Not sure if there's ActiveJob/Solid Queue usage yet — check `config/application.rb` for the queue adapter. If adding background jobs, prefer Solid Queue (Rails 8 native) over Sidekiq unless there's a specific reason.
+
+## Controllers thin, models fat
+
+Standard Rails pattern. If a controller action is >10 lines of logic, that logic belongs in a model method, service object under `app/services/`, or interactor. Keep controllers to: params → call business logic → redirect/render.
+
+## File naming
+
+- Models: `snake_case.rb`, class `CamelCase`, file matches table name singular
+- Controllers: `snake_case_controller.rb`, class `SnakeCaseController`, file matches resource plural
+- Views: `.html.erb` for HTML, `.turbo_stream.erb` for streams, `.json.jbuilder` for API JSON
+- Services (if under `app/services/`): `snake_case_service.rb`, class `SnakeCaseService`
+
+## Don't
+
+- Don't add `rack-cors` unless you're building an API. This app is not cross-origin.
+- Don't add `devise` if Auth is already in place — check `app/models/user.rb` + `config/routes.rb` for the existing auth scheme first.
+- Don't add Grape/Rails-API style controllers when Turbo Streams solve it. API-only controllers are for true JSON clients.

--- a/.claude/rules/web/design-quality.md
+++ b/.claude/rules/web/design-quality.md
@@ -1,7 +1,6 @@
 ---
 paths:
   - "app/views/**/*.erb"
-  - "app/components/**/*.{rb,erb}"
   - "app/assets/stylesheets/**/*.css"
 ---
 

--- a/.claude/rules/web/design-quality.md
+++ b/.claude/rules/web/design-quality.md
@@ -1,0 +1,68 @@
+---
+paths:
+  - "app/views/**/*.erb"
+  - "app/components/**/*.{rb,erb}"
+  - "app/assets/stylesheets/**/*.css"
+---
+
+# Web Design Quality Standards
+
+## Anti-Template Policy
+
+Do not ship generic template-looking UI. Frontend output should look intentional, opinionated, and specific to the product.
+
+### Banned Patterns
+
+- Default card grids with uniform spacing and no hierarchy
+- Stock hero section with centered headline, gradient blob, and generic CTA
+- Unmodified library defaults passed off as finished design
+- Flat layouts with no layering, depth, or motion
+- Uniform radius, spacing, and shadows across every component
+- Safe gray-on-white styling with one decorative accent color
+- Dashboard-by-numbers layouts with sidebar + cards + charts and no point of view
+- Default font stacks used without a deliberate reason
+
+### Required Qualities
+
+Every meaningful frontend surface should demonstrate at least four of these:
+
+1. Clear hierarchy through scale contrast
+2. Intentional rhythm in spacing, not uniform padding everywhere
+3. Depth or layering through overlap, shadows, surfaces, or motion
+4. Typography with character and a real pairing strategy
+5. Color used semantically, not just decoratively
+6. Hover, focus, and active states that feel designed
+7. Grid-breaking editorial or bento composition where appropriate
+8. Texture, grain, or atmosphere when it fits the visual direction
+9. Motion that clarifies flow instead of distracting from it
+10. Data visualization treated as part of the design system, not an afterthought
+
+## Before Writing Frontend Code
+
+1. Pick a specific style direction. Avoid vague defaults like "clean minimal".
+2. Define a palette intentionally.
+3. Choose typography deliberately.
+4. Gather at least a small set of real references.
+5. Use ECC design/frontend skills where relevant.
+
+## Worthwhile Style Directions
+
+- Editorial / magazine
+- Neo-brutalism
+- Glassmorphism with real depth
+- Dark luxury or light luxury with disciplined contrast
+- Bento layouts
+- Scrollytelling
+- 3D integration
+- Swiss / International
+- Retro-futurism
+
+Do not default to dark mode automatically. Choose the visual direction the product actually wants.
+
+## Component Checklist
+
+- [ ] Does it avoid looking like a default Tailwind or shadcn template?
+- [ ] Does it have intentional hover/focus/active states?
+- [ ] Does it use hierarchy rather than uniform emphasis?
+- [ ] Would this look believable in a real product screenshot?
+- [ ] If it supports both themes, do both light and dark feel intentional?

--- a/.claude/rules/web/performance.md
+++ b/.claude/rules/web/performance.md
@@ -1,0 +1,70 @@
+---
+paths:
+  - "app/views/**/*.erb"
+  - "app/javascript/**/*.js"
+  - "app/assets/**/*.{js,css}"
+  - "config/importmap.rb"
+---
+
+# Web Performance Rules
+
+## Core Web Vitals Targets
+
+| Metric | Target |
+|--------|--------|
+| LCP | < 2.5s |
+| INP | < 200ms |
+| CLS | < 0.1 |
+| FCP | < 1.5s |
+| TBT | < 200ms |
+
+## Bundle Budget
+
+| Page Type | JS Budget (gzipped) | CSS Budget |
+|-----------|---------------------|------------|
+| Landing page | < 150kb | < 30kb |
+| App page | < 300kb | < 50kb |
+| Microsite | < 80kb | < 15kb |
+
+## Loading Strategy
+
+1. Inline critical above-the-fold CSS where justified
+2. Preload the hero image and primary font only
+3. Defer non-critical CSS or JS
+4. Dynamically import heavy libraries
+
+```js
+const gsapModule = await import('gsap');
+const { ScrollTrigger } = await import('gsap/ScrollTrigger');
+```
+
+## Image Optimization
+
+- Explicit `width` and `height`
+- `loading="eager"` plus `fetchpriority="high"` for hero media only
+- `loading="lazy"` for below-the-fold assets
+- Prefer AVIF or WebP with fallbacks
+- Never ship source images far beyond rendered size
+
+## Font Loading
+
+- Max two font families unless there is a clear exception
+- `font-display: swap`
+- Subset where possible
+- Preload only the truly critical weight/style
+
+## Animation Performance
+
+- Animate compositor-friendly properties only
+- Use `will-change` narrowly and remove it when done
+- Prefer CSS for simple transitions
+- Use `requestAnimationFrame` or established animation libraries for JS motion
+- Avoid scroll handler churn; use IntersectionObserver or well-behaved libraries
+
+## Performance Checklist
+
+- [ ] All images have explicit dimensions
+- [ ] No accidental render-blocking resources
+- [ ] No layout shifts from dynamic content
+- [ ] Motion stays on compositor-friendly properties
+- [ ] Third-party scripts load async/defer and only when needed

--- a/.claude/rules/web/security.md
+++ b/.claude/rules/web/security.md
@@ -1,0 +1,62 @@
+---
+paths:
+  - "app/**/*.{rb,erb,js,css}"
+  - "config/**/*.{rb,yml}"
+  - "lib/**/*.rb"
+---
+
+# Web Security Rules
+
+## Content Security Policy
+
+Always configure a production CSP.
+
+### Nonce-Based CSP
+
+Use a per-request nonce for scripts instead of `'unsafe-inline'`.
+
+```text
+Content-Security-Policy:
+  default-src 'self';
+  script-src 'self' 'nonce-{RANDOM}' https://cdn.jsdelivr.net;
+  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+  img-src 'self' data: https:;
+  font-src 'self' https://fonts.gstatic.com;
+  connect-src 'self' https://*.example.com;
+  frame-src 'none';
+  object-src 'none';
+  base-uri 'self';
+```
+
+Adjust origins to the project. Do not cargo-cult this block unchanged.
+
+## XSS Prevention
+
+- Never inject unsanitized HTML
+- Avoid `innerHTML` / `dangerouslySetInnerHTML` unless sanitized first
+- Escape dynamic template values
+- Sanitize user HTML with a vetted local sanitizer when absolutely necessary
+
+## Third-Party Scripts
+
+- Load asynchronously
+- Use SRI when serving from a CDN
+- Audit quarterly
+- Prefer self-hosting for critical dependencies when practical
+
+## HTTPS and Headers
+
+```text
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: camera=(), microphone=(), geolocation=()
+```
+
+## Forms
+
+- CSRF protection on state-changing forms
+- Rate limiting on submission endpoints
+- Validate client and server side
+- Prefer honeypots or light anti-abuse controls over heavy-handed CAPTCHA defaults

--- a/.claude/skills/deploy-to-vm/SKILL.md
+++ b/.claude/skills/deploy-to-vm/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: deploy-to-vm
+description: Deploy clawtrol changes to the Ubuntu VM (192.168.100.186) via git push → remote pull → optional docker restart → smoke check. Enforces safety rails (no uncommitted work, no out-of-sync branches, no surprise force-pushes). Use when ready to ship a change to the running instance at the VM.
+argument-hint: "[--no-restart] [--skip-smoke] [--branch <name>] [--force-sync]"
+trigger: /deploy-to-vm
+---
+
+# deploy-to-vm
+
+Deploy local commits to the VM-hosted clawtrol instance.
+
+## Target
+
+- **VM:** 192.168.100.186 (Ubuntu)
+- **User:** ggorbalan
+- **SSH key:** `~/.ssh/id_rsa`
+- **Remote repo path:** `~/clawdeck/` (folder named `clawdeck` historically; the upstream repo is `wolverin0/clawtrol`)
+- **Service port:** 4001 (docker-compose maps container 3000 → host 4001)
+- **DB:** Postgres, database `clawdeck_production`
+- **Stack:** Rails 8.1 + Postgres + Docker Compose
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| (none) | Full deploy: push → pull → restart → smoke-check |
+| `--no-restart` | Skip docker compose restart (use when changes are docs-only) |
+| `--skip-smoke` | Skip HTTP smoke check at port 4001 |
+| `--branch <name>` | Deploy a specific branch instead of current |
+| `--force-sync` | Allow deploy even if local has uncommitted changes (DANGEROUS — ask user first) |
+
+## Non-negotiable pre-flight checks
+
+Before any network operation:
+
+1. **Local must be clean.**
+   ```bash
+   git status --porcelain
+   ```
+   If output is non-empty, STOP and report. Do NOT deploy dirty. Require `--force-sync` + user acknowledgment before proceeding.
+
+2. **Local must be up-to-date with origin.**
+   ```bash
+   git fetch origin
+   LOCAL=$(git rev-parse @)
+   REMOTE=$(git rev-parse @{u})
+   BASE=$(git merge-base @ @{u})
+   ```
+   - If `LOCAL == REMOTE`: in sync.
+   - If `LOCAL == BASE` (remote ahead): STOP. Pull first.
+   - If `REMOTE == BASE` (local ahead): OK to push.
+   - Otherwise (divergent): STOP. Fix the divergence first.
+
+3. **SSH connectivity works.**
+   ```bash
+   ssh -i ~/.ssh/id_rsa -o BatchMode=yes -o ConnectTimeout=8 ggorbalan@192.168.100.186 "echo ok"
+   ```
+   If this fails, report auth/network error. Don't continue.
+
+4. **VM has no uncommitted changes that would be blown away.**
+   ```bash
+   ssh -i ~/.ssh/id_rsa ggorbalan@192.168.100.186 "cd ~/clawdeck && git status --porcelain"
+   ```
+   If non-empty, STOP. Show the diff to the user. The VM may have local config edits (like `db/schema.rb` drift from migrations) that shouldn't be overwritten. Require user confirmation before continuing.
+
+## Deploy flow
+
+### Step 1. Push
+
+```bash
+BRANCH=$(git branch --show-current)
+git push origin "$BRANCH"
+```
+
+If the branch is new on origin, push with `-u`. If the push is rejected, do NOT force-push — surface the rejection and stop.
+
+### Step 2. Remote fetch + checkout + pull
+
+```bash
+ssh -i ~/.ssh/id_rsa ggorbalan@192.168.100.186 "set -e
+cd ~/clawdeck
+git fetch origin
+git checkout $BRANCH
+git pull --ff-only origin $BRANCH"
+```
+
+`--ff-only` is mandatory. If the VM's HEAD is divergent, that's a flag — requires manual resolution, not automatic merge.
+
+### Step 3. Restart services (unless `--no-restart`)
+
+The app runs under Docker Compose on the VM. Detect the running compose project and restart:
+
+```bash
+ssh -i ~/.ssh/id_rsa ggorbalan@192.168.100.186 "set -e
+cd ~/clawdeck
+docker compose ps --services 2>&1 | head -5
+docker compose restart clawdeck"
+```
+
+If migrations are needed, user triggers that explicitly — do NOT auto-migrate on deploy. Migrations are a separate workflow: `ssh … "cd ~/clawdeck && docker compose exec clawdeck bin/rails db:migrate"`.
+
+### Step 4. Smoke check (unless `--skip-smoke`)
+
+Wait 5 seconds for the service to come up, then:
+
+```bash
+curl -sSf -o /dev/null -w "HTTP %{http_code}\n" http://192.168.100.186:4001/ || {
+  echo "SMOKE FAIL: service not responding on :4001"
+  echo "Check logs: ssh ... 'cd ~/clawdeck && docker compose logs --tail 50 clawdeck'"
+  exit 1
+}
+```
+
+HTTP 200/301/302 = OK. Anything else = report and let user investigate.
+
+### Step 5. Report
+
+```
+DEPLOYED: <branch> @ <short-sha>
+  pushed:    $(git log origin/$BRANCH -1 --format='%h %s')
+  VM pulled: <VM's new HEAD>
+  restart:   ok (or skipped)
+  smoke:     HTTP 200 (or the actual code)
+
+Logs available at:
+  ssh -i ~/.ssh/id_rsa ggorbalan@192.168.100.186 "cd ~/clawdeck && docker compose logs -f --tail 100"
+```
+
+## Rollback
+
+The skill does NOT auto-rollback on smoke-fail — that's a decision for the user. Rollback pattern:
+
+```bash
+ssh -i ~/.ssh/id_rsa ggorbalan@192.168.100.186 "set -e
+cd ~/clawdeck
+git reset --hard HEAD@{1}
+docker compose restart clawdeck"
+```
+
+`HEAD@{1}` is the previous state (before the most recent `pull`). If multiple pulls happened, bump the number.
+
+## What this skill will NEVER do
+
+- **Force-push** to origin.
+- **Auto-run migrations.** Destructive to prod data if they fail mid-flight.
+- **`rm`, `drop database`, `reset --hard` without explicit user request.**
+- **Deploy through SSH if local is dirty** (unless `--force-sync` + user acknowledges).
+- **Overwrite VM-local uncommitted changes.** Report + ask first.
+- **Silently skip the smoke check.** If `--skip-smoke` is passed, it says so in the report. User owns the risk.
+
+## When to use
+
+Use after:
+- `git commit` lands a local change you want in prod
+- A PR merges to a branch the VM already tracks
+- You've pulled from origin and want the VM to match
+
+Don't use for:
+- Schema migrations (run those as explicit one-off)
+- Config changes requiring container rebuild (that's `docker compose build`, handle manually)
+- Breaking changes without a rollback plan
+
+## Known VM state (as of 2026-04-19)
+
+- Branch: `docs/restore-runbook`
+- HEAD: `b54b354` (same as local after clone)
+- Has one uncommitted local change: `M db/schema.rb` — this is schema drift that predates this skill. Pre-flight check #4 will flag it on every deploy until resolved. Resolution path: either commit it on the VM and push to origin, or revert it locally on the VM if it's unwanted drift.
+
+## Caveats
+
+- **OneDrive latency:** this skill runs from a OneDrive-backed repo. Every `git fetch/push` touches OneDrive-synced `.git/` files. Expect slight operation slowness, not a correctness issue.
+- **SSH BatchMode:** all SSH commands use `BatchMode=yes` to fail fast on auth issues rather than hang on password prompts. If your SSH key setup changes, these will fail loudly — that's intentional.
+- **Branch naming:** local and remote `~/clawdeck/` on the VM track the same `origin`. The historical naming mismatch (local folder `clawdeck` vs upstream repo `clawtrol`) does not affect the deploy flow but can confuse people reading docs.

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ app/assets/images/*.mp4
 # Dolt database files (added by bd init)
 .dolt/
 *.db
+.claude/_backups/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,15 @@ Use this map first. Most recent confusion came from editing the wrong folder.
 
 ### Canonical vs mirror folders
 
+**UPDATED 2026-04-19** — Workflow shifted from SSH-edit-on-VM to local-clone + deploy-to-VM. The Windows local dir now holds a FULL git clone, not a docs mirror. Edits happen locally; deploys use `/deploy-to-vm` skill.
+
 | Role | Path | Status | Notes |
 |---|---|---|---|
-| Canonical ClawTrol codebase | `/home/ggorbalan/clawdeck` | **WRITE HERE** | Rails app, git repo, running service |
-| ClawTrol docs mirror on Windows | `G:\_OneDrive\OneDrive\Desktop\Py Apps\clawtrol` | Mirror/docs only | No `.git`, do not treat as runtime codebase |
-| Scratch patch dump | `G:\_OneDrive\OneDrive\Desktop\Py Apps\clawdeck_remote_work` | Non-canonical | Isolated files, not the live repo |
+| **Local working copy (primary)** | `G:\_OneDrive\OneDrive\Desktop\Py Apps\clawtrol` | **WRITE HERE** | Full clone of `wolverin0/clawtrol`, same remote as VM. Work locally, deploy via `/deploy-to-vm`. |
+| VM deployment target | `/home/ggorbalan/clawdeck` | Pulled-from-git | Running Rails service, pulls from origin. Do NOT edit directly unless debugging on the VM is required. |
+| VM worktree (alternate branch) | `/home/ggorbalan/factory-workspaces/clawtrol-minimax` | Secondary working copy | Git worktree of `~/clawdeck/.git`. Separate branch, separate working dir. |
+| Audit workspace (archived) | `G:\_OneDrive\OneDrive\Desktop\Py Apps\clawtrol-workspace` | Preserved audit docs | AUDIT.md, FIX_PROMPTS.md, FEATURE_IDEAS.md, roadmap.md, obsidian-vault/, screenshots. Moved aside from clawtrol/ during the 2026-04-19 re-clone. Reference only. |
+| Scratch patch dump | `G:\_OneDrive\OneDrive\Desktop\Py Apps\clawdeck_remote_work` | Non-canonical | Isolated files from prior remote-work flow, not the live repo |
 | Repo comparison clones (Windows) | `G:\_OneDrive\OneDrive\Desktop\Py Apps\gitclones` | Reference only | For benchmarking patterns |
 | Repo comparison clones (Ubuntu) | `/home/ggorbalan/gitclone` | Reference only | For benchmarking patterns |
 | OpenClaw workspace | `/home/ggorbalan/.openclaw/workspace` | Separate project | Cognitive/memory files, not ClawTrol app code |
@@ -20,24 +24,35 @@ Use this map first. Most recent confusion came from editing the wrong folder.
 ### Runtime endpoints
 
 - ClawTrol app URL: `http://192.168.100.186:4001`
-- Service unit: `systemctl --user status clawdeck-web.service`
+- Service unit: `systemctl --user status clawdeck-web.service` (or via `docker compose ps` in `~/clawdeck/`)
+
+### Deploy
+
+Use the `/deploy-to-vm` skill at `.claude/skills/deploy-to-vm/SKILL.md`. Do NOT SSH-edit on the VM for non-emergency changes. The skill enforces clean-local + up-to-date-with-origin pre-flight + refuses to force-push.
 
 ## 2) Mandatory Preflight Before Any Edit
 
-Run these checks in order before coding:
+All edits happen in the **local clone** at `G:\_OneDrive\OneDrive\Desktop\Py Apps\clawtrol\`. Run these checks locally in order before coding:
 
 ```bash
-# 1) Confirm machine/repo
-ssh ggorbalan@192.168.100.186 'cd ~/clawdeck && pwd && git rev-parse --show-toplevel'
+# 1) Confirm cwd is the local clawtrol clone
+pwd && git rev-parse --show-toplevel
+# Expected: .../clawtrol  (NOT clawtrol-workspace, NOT clawdeck_remote_work)
 
-# 2) Confirm branch + dirty state
-ssh ggorbalan@192.168.100.186 'cd ~/clawdeck && git branch --show-current && git status --short'
+# 2) Confirm origin matches the canonical repo
+git remote get-url origin
+# Expected: https://github.com/wolverin0/clawtrol.git
 
-# 3) Confirm target file exists in canonical repo
-ssh ggorbalan@192.168.100.186 'cd ~/clawdeck && ls -la <target_path>'
+# 3) Confirm branch + dirty state + sync with origin
+git branch --show-current
+git status --short
+git fetch origin && git status -uno   # see if behind/ahead
+
+# 4) Confirm target file exists locally
+ls -la <target_path>
 ```
 
-If these do not point to `/home/ggorbalan/clawdeck`, stop and re-route.
+If `pwd` does not end in `clawtrol` OR origin is not `wolverin0/clawtrol`, stop and re-route. Do NOT SSH to the VM to edit. Pre-deploy verification of the VM state is handled by the `/deploy-to-vm` skill, not the edit preflight.
 
 ## 3) Documentation Source-of-Truth Policy
 
@@ -143,18 +158,21 @@ If any gate fails, do not mark task done.
 
 ## 8) Collaboration Rules for Agents
 
-1. Edit code in `/home/ggorbalan/clawdeck` only.
+1. Edit code in the local clone only (`G:\_OneDrive\OneDrive\Desktop\Py Apps\clawtrol\`). Never SSH-edit `/home/ggorbalan/clawdeck` for non-emergency work — see `.claude/rules/local-first-workflow.md`.
 2. Avoid broad refactors in dirty worktrees unless explicitly requested.
-3. Never use destructive git commands (`reset --hard`, `checkout --`) unless asked.
-4. When context is ambiguous, verify path + repo before touching files.
+3. Never use destructive git commands (`reset --hard`, `checkout --`, force-push) unless asked.
+4. When context is ambiguous, run the section 2 preflight before touching files.
 5. Prefer small reversible changes with explicit validation steps.
 6. Keep roadmap checkboxes updated in the same execution window.
+7. Ship via `/deploy-to-vm`. Do not `git pull` directly on the VM as part of a normal change.
 
 ## 9) Common Pitfalls and Fixes
 
 ### Pitfall: "I changed files but app did not change"
-Cause: edited a mirror/non-canonical folder.
-Fix: re-run preflight, ensure edits happen in `/home/ggorbalan/clawdeck`.
+Cause: either (a) edited the wrong folder (`clawtrol-workspace/`, `clawdeck_remote_work/`, or a `gitclones/` reference clone), or (b) edited locally but never deployed.
+Fix:
+- Re-run section 2 preflight; confirm `pwd` ends in `clawtrol` and origin is `wolverin0/clawtrol`.
+- If the local change is committed but the VM is unchanged, run `/deploy-to-vm` to push + pull on VM + restart the service.
 
 ### Pitfall: "Nav differs across pages"
 Cause: duplicated nav partials drifting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ These load automatically based on the files you touch:
 |---|---|
 | `.claude/rules/local-first-workflow.md` | Always (no path filter) |
 | `.claude/rules/rails-conventions.md` | `app/`, `config/`, `db/migrate/`, `test/`, `Gemfile` |
-| `.claude/rules/web/design-quality.md` | `app/views/**/*.erb`, `app/components/**/*`, `app/assets/stylesheets/**/*.css` |
+| `.claude/rules/web/design-quality.md` | `app/views/**/*.erb`, `app/assets/stylesheets/**/*.css` |
 | `.claude/rules/web/performance.md` | `app/views/**/*.erb`, `app/javascript/**/*.js`, `app/assets/**/*.{js,css}`, `config/importmap.rb` |
 | `.claude/rules/web/security.md` | `app/**/*.{rb,erb,js,css}`, `config/**/*.{rb,yml}`, `lib/**/*.rb` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# CLAUDE.md — ClawTrol (Claude-specific entry point)
+
+**Canonical workflow lives in `AGENTS.md`.** Read it before any non-trivial change. This file only adds Claude Code–specific guidance not covered there.
+
+## Where to write
+
+- **Edit here** (local clone): `G:\_OneDrive\OneDrive\Desktop\Py Apps\clawtrol\`
+- Never SSH-edit `/home/ggorbalan/clawdeck` for non-emergency work — see `.claude/rules/local-first-workflow.md`.
+- Deploy with the `/deploy-to-vm` skill at `.claude/skills/deploy-to-vm/`.
+
+## Auto-loaded rules
+
+These load automatically based on the files you touch:
+
+| Rule | Triggers on |
+|---|---|
+| `.claude/rules/local-first-workflow.md` | Always (no path filter) |
+| `.claude/rules/rails-conventions.md` | `app/`, `config/`, `db/migrate/`, `test/`, `Gemfile` |
+| `.claude/rules/web/design-quality.md` | `app/views/**/*.erb`, `app/components/**/*`, `app/assets/stylesheets/**/*.css` |
+| `.claude/rules/web/performance.md` | `app/views/**/*.erb`, `app/javascript/**/*.js`, `app/assets/**/*.{js,css}`, `config/importmap.rb` |
+| `.claude/rules/web/security.md` | `app/**/*.{rb,erb,js,css}`, `config/**/*.{rb,yml}`, `lib/**/*.rb` |
+
+Plus the always-loaded global rules in `~/.claude/rules/` (coding-style, git-workflow, security, testing).
+
+## Verification
+
+Before claiming any work done, run the relevant subset of section 6 of `AGENTS.md`:
+- Touched Ruby? → `bin/rubocop` + `bin/rails test`
+- Touched ERB/JS/CSS? → load the page locally (`bin/dev`) and confirm visually
+- Touched migrations? → `bin/rails db:migrate` on a clean local DB
+- Pre-deploy? → `bin/ci`


### PR DESCRIPTION
## Summary

Per-project `.claude/` curation via the `project-curate` skill. Hand-tunes the agent context to the 2026-04-19 local-clone + deploy-to-vm workflow shift, replacing prior SSH-edit-on-VM assumptions.

- AGENTS.md sections 2/8/9 rewritten: preflight is now local checks (no SSH), collab rule #1 is "edit local clone", pitfall covers the deploy-to-vm round trip.
- New CLAUDE.md (30 lines): minimal Claude-specific entry pointing to AGENTS.md + the auto-loaded `.claude/rules/` table.
- 5 path-scoped rules: `local-first-workflow.md`, `rails-conventions.md`, `web/{design-quality,performance,security}.md`. ECC has no `rules/ruby/`, so Rails conventions are project-generated.
- `.claude/skills/deploy-to-vm/` skill scaffold.
- `.gitignore` now ignores `.claude/_backups/` (curate-script tarball).
- `.claude/_curation_log_2026-04-19.md` documents the full pass.

## Self-verify

Coordinator self-verify (skill step 7b) on the generated rules caught 4 drifts, all fixed in `444402d`:
- `rails-conventions.md` Tailwind path: `config/tailwind.config.js` → `app/assets/tailwind/application.css`
- `rails-conventions.md` Secrets: project uses `dotenv-rails`, NOT Rails encrypted credentials
- `rails-conventions.md` Solid Queue hedge removed (it's in the Gemfile)
- `web/design-quality.md` dead `app/components/**/*` glob removed

## Test plan

- [ ] On main, run `/memory` in a fresh Claude pane — confirm AGENTS.md, CLAUDE.md, and the 5 rules are listed
- [ ] Touch `app/assets/tailwind/application.css` in a scratch session — confirm `web/design-quality.md` newly activates
- [ ] Touch a `db/migrate/*.rb` — confirm `rails-conventions.md` activates
- [ ] No app/runtime impact (this PR only changes agent-context files)