### PR TITLE
feat(ops): operational hardening — DB safety + health + drift check + path env

### DIFF
--- a/app/controllers/concerns/output_renderable.rb
+++ b/app/controllers/concerns/output_renderable.rb
@@ -32,8 +32,9 @@ module OutputRenderable
     return nil if path_components.any? { |component| component.start_with?(".") && component != "." }
 
     # Define allowed base directories (project and storage only)
-    project_root = File.expand_path("~/clawdeck")
-    storage_root = File.expand_path("~/clawdeck/storage")
+    # Env-overridable so non-VM environments can point at a temp tree.
+    project_root = File.expand_path(ENV["CLAWTROL_PROJECT_DIR"].presence || "~/clawdeck")
+    storage_root = File.expand_path(ENV["CLAWTROL_STORAGE_DIR"].presence || File.join(project_root, "storage"))
 
     # Allow caller to override allowed_dirs (for board-specific project paths)
     allowed_dirs ||= [project_root, storage_root]

--- a/app/controllers/file_viewer_controller.rb
+++ b/app/controllers/file_viewer_controller.rb
@@ -4,10 +4,12 @@ class FileViewerController < ApplicationController
   rate_limit to: 60, within: 1.minute, with: -> { render plain: "Rate limit exceeded. Try again later.", status: :too_many_requests }
   include MarkdownSanitizationHelper
 
-  WORKSPACE = Pathname.new(File.expand_path("~/.openclaw/workspace")).freeze
+  # Allowed directory roots are env-overridable so tests + non-VM environments
+  # don't have to seed real paths under ~/. Defaults match the prod VM layout.
+  WORKSPACE = Pathname.new(File.expand_path(ENV["CLAWTROL_WORKSPACE_DIR"].presence || "~/.openclaw/workspace")).freeze
   WORKSPACE_PREFIX = (WORKSPACE.to_s + "/").freeze
-  REPORTS_DIR = Pathname.new(File.expand_path("~/nightshift-reports")).freeze
-  CLAWDECK_DIR = Pathname.new(File.expand_path("~/clawdeck")).freeze
+  REPORTS_DIR = Pathname.new(File.expand_path(ENV["CLAWTROL_REPORTS_DIR"].presence || "~/nightshift-reports")).freeze
+  CLAWDECK_DIR = Pathname.new(File.expand_path(ENV["CLAWTROL_PROJECT_DIR"].presence || "~/clawdeck")).freeze
   ALLOWED_DIRS = [WORKSPACE, REPORTS_DIR, CLAWDECK_DIR].freeze
 
   # Dotfiles/dotdirs that should never be served or listed

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,7 +1,61 @@
+# frozen_string_literal: true
+
+# Deep health check used by external monitors. /up stays as the Rails default
+# process-alive probe (returns 200 just because the boot finished). /health
+# additionally validates that the DB read path, Solid Queue, Solid Cache, and
+# the Active Record encryption keys are functional. Anything broken returns
+# 503 with a JSON body that names the failing subsystem.
 class HealthController < ApplicationController
   allow_unauthenticated_access
 
   def show
-    render json: { status: "ok", time: Time.current }
+    checks = {
+      database: check_database,
+      solid_queue: check_solid_queue,
+      cache: check_cache,
+      ar_encryption: check_ar_encryption
+    }
+
+    if checks.values.all? { |v| v[:ok] }
+      render json: { status: "ok", time: Time.current.iso8601, checks: checks }
+    else
+      render json: { status: "degraded", time: Time.current.iso8601, checks: checks }, status: :service_unavailable
+    end
+  end
+
+  private
+
+  def check_database
+    ActiveRecord::Base.connection.execute("SELECT 1")
+    { ok: true }
+  rescue StandardError => e
+    { ok: false, error: "#{e.class}: #{e.message}".truncate(200) }
+  end
+
+  def check_solid_queue
+    SolidQueue::Job.connection.execute("SELECT 1")
+    { ok: true }
+  rescue StandardError => e
+    { ok: false, error: "#{e.class}: #{e.message}".truncate(200) }
+  end
+
+  def check_cache
+    Rails.cache.write("health_check", Time.current.to_i, expires_in: 30.seconds)
+    Rails.cache.read("health_check") ? { ok: true } : { ok: false, error: "cache write/read mismatch" }
+  rescue StandardError => e
+    { ok: false, error: "#{e.class}: #{e.message}".truncate(200) }
+  end
+
+  # If AR encryption is misconfigured, every encrypted attribute read will
+  # blow up at request time. Cheap to verify here.
+  def check_ar_encryption
+    return { ok: true, skipped: true } unless ActiveRecord::Encryption.config.primary_key.present?
+
+    test_value = "health-#{SecureRandom.hex(4)}"
+    encrypted = ActiveRecord::Encryption.encryptor.encrypt(test_value)
+    decrypted = ActiveRecord::Encryption.encryptor.decrypt(encrypted)
+    decrypted == test_value ? { ok: true } : { ok: false, error: "encrypt/decrypt mismatch" }
+  rescue StandardError => e
+    { ok: false, error: "#{e.class}: #{e.message}".truncate(200) }
   end
 end

--- a/app/models/task/agent_integration.rb
+++ b/app/models/task/agent_integration.rb
@@ -164,7 +164,9 @@ module Task::AgentIntegration
   end
 
   def debate_storage_path
-    File.expand_path("~/clawdeck/storage/debates/task_#{id}")
+    base = ENV["CLAWTROL_STORAGE_DIR"].presence ||
+      File.join(ENV["CLAWTROL_PROJECT_DIR"].presence || "~/clawdeck", "storage")
+    File.expand_path(File.join(base, "debates", "task_#{id}"))
   end
 
   def debate_synthesis_path

--- a/app/services/cherry_pick_service.rb
+++ b/app/services/cherry_pick_service.rb
@@ -4,7 +4,7 @@
 # Provides safe, audited git operations with conflict detection and rollback.
 class CherryPickService
   PLAYGROUND_PATH = File.expand_path(ENV.fetch("CHERRY_PICK_PLAYGROUND_PATH", "~/.openclaw/workspace/clawtrolplayground"))
-  PRODUCTION_PATH = File.expand_path("~/clawdeck")
+  PRODUCTION_PATH = File.expand_path(ENV["CLAWTROL_PROJECT_DIR"].presence || "~/clawdeck")
   MAX_CHERRY_PICK_COMMITS = 20
 
   Result = Struct.new(:success, :message, :data, keyword_init: true)

--- a/app/services/pipeline/auto_review_service.rb
+++ b/app/services/pipeline/auto_review_service.rb
@@ -70,8 +70,8 @@ module Pipeline
       board_name = @task.board&.name.to_s.downcase
 
       case board_name
-      when "clawdeck"
-        File.expand_path("~/clawdeck")
+      when "clawdeck", "clawtrol"
+        File.expand_path(ENV["CLAWTROL_PROJECT_DIR"].presence || "~/clawdeck")
       when "personal dashboard"
         "/mnt/pyapps/personaldashboard"
       when "whatsapp bot"

--- a/lib/tasks/db_integrity.rake
+++ b/lib/tasks/db_integrity.rake
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Schema integrity drift detector
+#
+# Catches the failure mode where schema_migrations marks a migration as
+# applied but the columns / indexes the migration was supposed to create
+# are missing in the live DB. That happened to the pipeline_* columns on
+# tasks (PR #33) and went undetected for weeks.
+#
+# Two sub-tasks:
+#   db:integrity:migrations  — every migration file has a row in schema_migrations
+#   db:integrity:expected    — a curated list of (table, column) pairs we know must exist
+
+EXPECTED_COLUMNS = {
+  "tasks" => %w[
+    pipeline_stage pipeline_type pipeline_enabled pipeline_log
+    status priority assigned_to_agent agent_session_id
+  ],
+  "users" => %w[email_address password_digest agent_auto_mode],
+  "boards" => %w[name user_id],
+  "api_tokens" => %w[token_digest token_prefix user_id],
+  "agent_activity_events" => %w[task_id run_id event_type seq],
+  "task_runs" => %w[task_id run_id status]
+}.freeze
+
+namespace :db do
+  namespace :integrity do
+    desc "Verify every migration file has a row in schema_migrations"
+    task migrations: :environment do
+      file_versions = Dir.glob(Rails.root.join("db/migrate/*.rb"))
+        .map { |p| File.basename(p).split("_").first }
+        .sort
+
+      db_versions = ActiveRecord::Base.connection
+        .execute("SELECT version FROM schema_migrations ORDER BY version")
+        .map { |r| r["version"] }
+
+      missing_in_db = file_versions - db_versions
+      missing_in_files = db_versions - file_versions
+
+      if missing_in_db.any? || missing_in_files.any?
+        puts "❌ schema_migrations drift detected"
+        puts "  Files not applied:    #{missing_in_db.inspect}" if missing_in_db.any?
+        puts "  In DB without file:   #{missing_in_files.inspect}" if missing_in_files.any?
+        abort
+      end
+
+      puts "✅ #{file_versions.size} migrations all reconciled"
+    end
+
+    desc "Verify expected (table, column) pairs exist in the DB"
+    task expected: :environment do
+      missing = []
+
+      EXPECTED_COLUMNS.each do |table, cols|
+        unless ActiveRecord::Base.connection.table_exists?(table)
+          missing << "#{table} (table)"
+          next
+        end
+
+        actual = ActiveRecord::Base.connection.columns(table).map(&:name)
+        cols.each do |col|
+          missing << "#{table}.#{col}" unless actual.include?(col)
+        end
+      end
+
+      if missing.any?
+        puts "❌ Schema integrity drift — expected columns missing:"
+        missing.each { |m| puts "  - #{m}" }
+        abort
+      end
+
+      total = EXPECTED_COLUMNS.values.flatten.size
+      puts "✅ #{total} expected columns across #{EXPECTED_COLUMNS.size} tables all present"
+    end
+
+    desc "Run all DB integrity checks"
+    task check: ["db:integrity:migrations", "db:integrity:expected"]
+  end
+end

--- a/lib/tasks/db_safety.rake
+++ b/lib/tasks/db_safety.rake
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# DB safety guards
+#
+# These hooks prevent destructive db: tasks from running against a database
+# whose name doesn't match the conventional test/development suffixes. They
+# specifically defend against the failure mode where DATABASE_URL (loaded from
+# /etc/clawtrol/clawtrol.env) silently shadows RAILS_ENV=test on the VM, so
+# `RAILS_ENV=test bundle exec rails db:schema:load` ends up running against
+# clawdeck_development. That happened 2026-04-27 and wiped prod.
+#
+# Bypass with FORCE_DESTRUCTIVE_DB=1 if you really mean it.
+
+DESTRUCTIVE_DB_TASKS = %w[
+  db:drop
+  db:drop:_unsafe
+  db:drop:all
+  db:reset
+  db:schema:load
+  db:schema:load:primary
+  db:setup
+  db:purge
+  db:purge:all
+].freeze
+
+PROTECTED_DB_NAME_PATTERN = /(_test\b|_test_\d+\b|_development\b|playground)/
+
+DESTRUCTIVE_DB_TASKS.each do |task_name|
+  next unless Rake::Task.task_defined?(task_name)
+
+  Rake::Task[task_name].enhance(["db:safety:guard"])
+end
+
+namespace :db do
+  namespace :safety do
+    desc "Abort if the current DB looks like production"
+    task guard: :environment do
+      next if ENV["FORCE_DESTRUCTIVE_DB"] == "1"
+
+      configs = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env)
+      configs.each do |config|
+        db_name = config.database.to_s
+        next if db_name.empty?
+
+        unless db_name.match?(PROTECTED_DB_NAME_PATTERN) && !db_name.start_with?("clawdeck_development")
+          warn <<~MSG
+
+            ❌ DB SAFETY GUARD blocked a destructive task on:
+                database: #{db_name}
+                env:      #{Rails.env}
+                source:   #{config.configuration_hash[:url] ? 'DATABASE_URL' : 'database.yml'}
+
+            This database name doesn't look like a safe test/dev target.
+            Common cause: DATABASE_URL set in your shell/env file overrides
+            RAILS_ENV. Run `unset DATABASE_URL DATABASE_ADMIN_URL` first, or
+            re-run with FORCE_DESTRUCTIVE_DB=1 if you really mean it.
+
+          MSG
+          abort "blocked by db:safety:guard"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes the foot-gun + observability gaps surfaced by the 2026-04-27 wipe incident (during which I accidentally ran \`db:schema:load\` against \`clawdeck_development\` because \`DATABASE_URL\` silently shadowed \`RAILS_ENV=test\`).

### Changes

1. **\`lib/tasks/db_safety.rake\`** — Rake hook intercepts every destructive \`db:\` task (\`drop\`, \`reset\`, \`schema:load\`, \`setup\`, \`purge\`) and aborts unless the target DB name contains \`_test\` / \`_development\` / \`playground\` AND is **not** \`clawdeck_development\`. Bypass with \`FORCE_DESTRUCTIVE_DB=1\` if you really mean it. **Verified** that this guard fires even when \`DISABLE_DATABASE_ENVIRONMENT_CHECK=1\` is set (the env var I had set on 2026-04-27).

2. **\`lib/tasks/db_integrity.rake\`** — \`db:integrity:migrations\` reconciles migration files vs \`schema_migrations\` rows; \`db:integrity:expected\` verifies a curated allowlist of \`(table, column)\` pairs that must exist (e.g. \`tasks.pipeline_stage\`). Catches the silent column-drift failure mode that hid the missing pipeline_* columns for weeks.

3. **\`app/controllers/health_controller.rb\`** — \`/health\` now validates DB read, Solid Queue, Solid Cache write/read, AR encryption encrypt/decrypt. Returns 503 with per-check details on any subsystem failure. \`/up\` stays as the cheap process-alive probe.

4. **Hardcoded paths to \`~/clawdeck\`, \`~/.openclaw/workspace\`** are now env-overridable across \`file_viewer_controller\`, \`output_renderable\`, \`cherry_pick_service\`, \`pipeline/auto_review_service\`, and \`Task#debate_storage_path\`. Defaults unchanged for production. New env vars: \`CLAWTROL_PROJECT_DIR\`, \`CLAWTROL_WORKSPACE_DIR\`, \`CLAWTROL_REPORTS_DIR\`, \`CLAWTROL_STORAGE_DIR\`.

5. **(VM-only, not in this PR)** \`~/.openclaw/workspace/scripts/clawtrol-backup.sh\` patched to:
   - Use container \`pg_dump\` (matches PG 15 server, fixes 2026-04-27 dump-restore PG17→PG15 incompatibility)
   - \`df\` pre-check requiring 500 MB free; on disk-full abort, emits Telegram alert (closes the silent 2026-04-25 gap)

## Test plan

- [x] DB safety guard manually verified on VM: blocks \`db:schema:load\` against \`clawdeck_development\` with and without \`DISABLE_DATABASE_ENVIRONMENT_CHECK=1\`.
- [x] Backup script patched + bash syntax check passed; dump test confirmed no PG17 directives.
- [ ] Full test suite green with \`CI=true\` (Bullet enabled) — running.