### PR TITLE
fix: drop nonexistent status column from TaskRun.create + integrity expectation

### DIFF
--- a/app/services/agent_completion_service.rb
+++ b/app/services/agent_completion_service.rb
@@ -179,8 +179,7 @@ class AgentCompletionService
       @task.task_runs.create!(
         run_id: run_id,
         agent_output: output_text,
-        prompt_used: @task.effective_prompt,
-        status: "completed"
+        prompt_used: @task.effective_prompt
       )
     end
 

--- a/lib/tasks/db_integrity.rake
+++ b/lib/tasks/db_integrity.rake
@@ -20,7 +20,7 @@ EXPECTED_COLUMNS = {
   "boards" => %w[name user_id],
   "api_tokens" => %w[token_digest token_prefix user_id],
   "agent_activity_events" => %w[task_id run_id event_type seq],
-  "task_runs" => %w[task_id run_id status]
+  "task_runs" => %w[task_id run_id run_number]
 }.freeze
 
 namespace :db do


### PR DESCRIPTION
Surfaced by `db:integrity:check` immediately after PR #36/#37 deployed: `task_runs.status` does not exist (never has). Two changes:

1. **`AgentCompletionService#store_agent_output_in_task_run`** removes `status: "completed"` from the `task_runs.create!` call. The wrapping `rescue StandardError` (line 188) was silently eating the `UnknownAttributeError`, so the create path was a quiet no-op — every new TaskRun creation lost its agent_output. The update path (when a TaskRun already existed) was unaffected.

2. **`db:integrity:expected`** asserted `task_runs.status` exists. Replace with `run_number` which actually does.

This is exactly the class of bug the integrity check was designed to catch — and it caught a real one on its first run.