### PR TITLE
feat: add Wezbridge orchestration control room

### DIFF
--- a/app/controllers/api/v1/orchestration_controller.rb
+++ b/app/controllers/api/v1/orchestration_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class OrchestrationController < BaseController
+      before_action -> { require_api_scope!("orchestration_bridge:sync") }
+
+      def sync
+        result = Orchestration::SyncIngestor.new(current_user).sync(sync_payload)
+        render json: {
+          server_time: Time.current.iso8601,
+          source: source_json(result.source),
+          accepted: result.accepted,
+          intents: result.intents
+        }
+      rescue Orchestration::InvalidRequest => e
+        render json: { error: e.message }, status: :unprocessable_entity
+      end
+
+      private
+
+      def sync_payload
+        request.request_parameters.slice(
+          "profile",
+          "generated_at",
+          "health",
+          "panes",
+          "tasks",
+          "events",
+          "messages",
+          "intent_results"
+        )
+      end
+
+      def source_json(source)
+        {
+          id: source.id,
+          profile: source.profile,
+          status: source.display_status,
+          last_seen_at: source.last_seen_at&.iso8601
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/control_room_controller.rb
+++ b/app/controllers/control_room_controller.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+class ControlRoomController < ApplicationController
+  before_action :set_task, only: %i[message approve retry cancel]
+
+  def show
+    @sources = current_user.orchestration_sources.most_recent
+    @source = selected_source(@sources)
+    @tasks = projected_tasks.includes(:agent_messages).order(updated_at: :desc).limit(250)
+    @pending_intents = current_user.orchestration_intents.pending.limit(100)
+    categorize_tasks
+    @selected_task = selected_task
+  end
+
+  def create_task
+    create_task_intent(kind: "task")
+  end
+
+  def ask
+    create_task_intent(kind: "question")
+  end
+
+  def message
+    source = source_for_task!(@task)
+    content = required_param(:content, maximum: 100_000)
+
+    intent = ApplicationRecord.transaction do
+      record = create_intent(source, "message", @task, { "content" => content })
+      record_operator_message(@task, record, content)
+      record
+    end
+
+    redirect_to control_room_path(task_id: @task.id),
+      notice: "Message queued as intent ##{intent.id}."
+  rescue Orchestration::InvalidRequest => e
+    redirect_to control_room_path(task_id: @task.id), alert: e.message
+  end
+
+  %i[approve retry cancel].each do |action|
+    define_method(action) do
+      source = source_for_task!(@task)
+      intent = create_intent(source, action.to_s, @task, {})
+      redirect_to control_room_path(task_id: @task.id),
+        notice: "#{action.to_s.titleize} queued as intent ##{intent.id}."
+    rescue Orchestration::InvalidRequest => e
+      redirect_to control_room_path(task_id: @task.id), alert: e.message
+    end
+  end
+
+  private
+
+  def projected_tasks
+    current_user.tasks.where("origin_session_key LIKE 'wezbridge:%'")
+  end
+
+  def selected_source(sources)
+    return sources.find_by(id: params[:source_id]) if params[:source_id].present?
+
+    sources.first
+  end
+
+  def categorize_tasks
+    @needs_attention = @tasks.select { |task| task.blocked? || task.needs_decision? }
+    @failures = @tasks.select { |task| source_state(task) == "failed" }
+    @active = @tasks.select { |task| %w[queued ready running review].include?(source_state(task)) && !task.blocked? }
+    @recent = @tasks.select { |task| %w[done cancelled].include?(source_state(task)) }.first(25)
+  end
+
+  def selected_task
+    return if params[:task_id].blank?
+
+    @tasks.find { |task| task.id == params[:task_id].to_i }
+  end
+
+  def create_task_intent(kind:)
+    source = source_for_create!
+    brief = required_param(:brief, maximum: 2_000)
+    title = params[:title].to_s.strip.presence || brief.truncate(120)
+    payload = {
+      "title" => title.truncate(500),
+      "brief" => brief,
+      "project" => required_param(:project, maximum: 200),
+      "kind" => kind,
+      "priority" => params[:priority].presence || "normal",
+      "acceptance" => params[:acceptance].to_s.strip.truncate(2_000)
+    }
+    intent = create_intent(source, "create_task", nil, payload)
+
+    redirect_to control_room_path(source_id: source.id),
+      notice: "#{kind == 'question' ? 'Question' : 'Task'} queued as intent ##{intent.id}."
+  rescue Orchestration::InvalidRequest => e
+    redirect_to control_room_path, alert: e.message
+  end
+
+  def create_intent(source, kind, task, payload)
+    payload = payload.merge("task_id" => task.origin_session_id) if task
+    current_user.orchestration_intents.create!(
+      orchestration_source: source,
+      task:,
+      kind:,
+      payload: Orchestration::PayloadSanitizer.call(payload)
+    )
+  end
+
+  def record_operator_message(task, intent, content)
+    task.agent_messages.create!(
+      direction: "outgoing",
+      message_type: "feedback",
+      content: Orchestration::PayloadSanitizer.text(content),
+      sender_name: "You",
+      metadata: {
+        "external_id" => "clawtrol-intent:#{intent.id}",
+        "intent_id" => intent.id,
+        "provenance" => "operator",
+        "source" => "clawtrol"
+      }
+    )
+  end
+
+  def set_task
+    @task = projected_tasks.find(params[:task_id])
+  end
+
+  def source_for_create!
+    source = current_user.orchestration_sources.find_by(id: params[:source_id])
+    source ||= current_user.orchestration_sources.most_recent.first
+    raise Orchestration::InvalidRequest, "Connect the Wezbridge bridge first." unless source
+
+    source
+  end
+
+  def source_for_task!(task)
+    profile = task.state_data.dig("orchestration", "profile")
+    source = current_user.orchestration_sources.find_by(profile:)
+    raise Orchestration::InvalidRequest, "The task's orchestration source is unavailable." unless source
+
+    source
+  end
+
+  def required_param(name, maximum:)
+    value = params[name].to_s.strip
+    raise Orchestration::InvalidRequest, "#{name.to_s.humanize} is required." if value.blank?
+    raise Orchestration::InvalidRequest, "#{name.to_s.humanize} is too long." if value.length > maximum
+
+    value
+  end
+
+  def source_state(task)
+    task.state_data.dig("orchestration", "source_state").to_s
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -6,6 +6,7 @@ class ProfilesController < ApplicationController
   def show
     @user = current_user
     @api_token = current_user.api_token
+    @orchestration_token = current_user.api_tokens.active.find_by(name: "Wezbridge control plane")
   end
 
   def test_connection
@@ -56,6 +57,25 @@ class ProfilesController < ApplicationController
     # copy-friendly UI element, not as a generic notice visible in logs/referrer.
     flash[:new_api_token] = @api_token.raw_token
     redirect_to settings_path, notice: "API token regenerated. Copy it now — it won't be shown again!"
+  end
+
+  def create_orchestration_token
+    current_user.api_tokens.active
+      .where(name: "Wezbridge control plane")
+      .find_each(&:revoke!)
+    token = current_user.api_tokens.create!(
+      name: "Wezbridge control plane",
+      scopes: ["orchestration_bridge:sync"]
+    )
+    flash[:new_orchestration_token] = token.raw_token
+    redirect_to settings_path, notice: "Wezbridge token created. Copy it now; it will not be shown again."
+  end
+
+  def revoke_orchestration_token
+    current_user.api_tokens.active
+      .where(name: "Wezbridge control plane")
+      .find_each(&:revoke!)
+    redirect_to settings_path, notice: "Wezbridge token revoked."
   end
 
   private

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -19,8 +19,9 @@ module NavigationHelper
           id: :tasks,
           label: "Tasks",
           icon: "📋",
-          controllers: %w[boards workflows],
+          controllers: %w[boards workflows control_room],
           items: [
+            { label: "Control Room", icon: "CR", url: control_room_path, controller: "control_room" },
             { label: "Board", icon: "📋", url: last_board_path, controller: "boards" },
             { label: "Workflows", icon: "🔄", url: workflows_path, controller: "workflows" }
           ]

--- a/app/models/orchestration_intent.rb
+++ b/app/models/orchestration_intent.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class OrchestrationIntent < ApplicationRecord
+  KINDS = %w[create_task message approve retry cancel].freeze
+  STATUSES = %w[pending applied rejected].freeze
+
+  belongs_to :user, inverse_of: :orchestration_intents
+  belongs_to :orchestration_source, inverse_of: :orchestration_intents
+  belongs_to :task, optional: true
+
+  validates :kind, inclusion: { in: KINDS }
+  validates :status, inclusion: { in: STATUSES }
+  validate :source_belongs_to_user
+  validate :task_belongs_to_user
+
+  scope :pending, -> { where(status: "pending").order(:id) }
+  scope :recent, -> { order(created_at: :desc) }
+
+  def as_bridge_json
+    {
+      id:,
+      kind:,
+      task_origin_key: task&.origin_session_key,
+      payload:,
+      created_at: created_at.iso8601
+    }
+  end
+
+  private
+
+  def source_belongs_to_user
+    return if orchestration_source.blank? || user_id == orchestration_source.user_id
+
+    errors.add(:orchestration_source, "must belong to the same user")
+  end
+
+  def task_belongs_to_user
+    return if task.blank? || user_id == task.user_id
+
+    errors.add(:task, "must belong to the same user")
+  end
+end

--- a/app/models/orchestration_source.rb
+++ b/app/models/orchestration_source.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class OrchestrationSource < ApplicationRecord
+  PROFILE_PATTERN = /\A[A-Za-z0-9._-]+\z/
+  STATUSES = %w[healthy degraded stale offline].freeze
+
+  belongs_to :user, inverse_of: :orchestration_sources
+  has_many :orchestration_intents, dependent: :destroy, inverse_of: :orchestration_source
+
+  validates :profile, presence: true, length: { maximum: 64 },
+    format: { with: PROFILE_PATTERN },
+    uniqueness: { scope: :user_id }
+  validates :status, inclusion: { in: STATUSES }
+  validates :last_error, length: { maximum: 2_000 }, allow_nil: true
+
+  scope :fresh, -> { where("last_seen_at >= ?", 90.seconds.ago) }
+  scope :most_recent, -> { order(last_seen_at: :desc, id: :asc) }
+
+  def stale?
+    last_seen_at.blank? || last_seen_at < 90.seconds.ago
+  end
+
+  def display_status
+    stale? ? "stale" : status
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -98,7 +98,7 @@ class Task < ApplicationRecord
   validates :origin_session_id, length: { maximum: 200 }, allow_nil: true
   validates :origin_session_key, length: { maximum: 200 }, allow_nil: true
   validates :origin_session_key, uniqueness: { scope: :user_id },
-    if: -> { origin_session_key.to_s.start_with?("hermes:") }
+    if: -> { mirrored_origin_key? }
   validates :session_type, inclusion: { in: ["oneshot", "persistent"] }, allow_nil: true
   validate :validation_command_is_safe, if: -> { validation_command.present? }
   # Activity tracking - must be declared before callbacks that use it
@@ -109,7 +109,8 @@ class Task < ApplicationRecord
   after_update :record_update_activities
   # Auto-spawn is opt-in only. Default behavior is manual spawn by operator/assistant.
   after_commit :fire_openclaw_on_in_progress, on: :update, if: -> {
-    saved_change_to_status? && status == "in_progress" && ENV["OPENCLAW_AUTO_SPAWN_ON_IN_PROGRESS"].to_s.downcase == "true"
+    saved_change_to_status? && status == "in_progress" && !orchestration_projection? &&
+      ENV["OPENCLAW_AUTO_SPAWN_ON_IN_PROGRESS"].to_s.downcase == "true"
   }
   after_update :create_status_notification, if: :saved_change_to_status?
   after_save :auto_assign_on_up_next
@@ -190,6 +191,7 @@ end
   private
   # Auto-assign tasks to agent when created with up_next status
   def auto_assign_to_agent
+    return if orchestration_projection?
     return unless status == "up_next" && !assigned_to_agent?
 
     update_columns(assigned_to_agent: true, assigned_at: Time.current)
@@ -197,6 +199,7 @@ end
 
   # Auto-assign tasks when status changes to up_next
   def auto_assign_on_up_next
+    return if orchestration_projection?
     return unless saved_change_to_status? && status == "up_next" && !assigned_to_agent?
 
     update_columns(assigned_to_agent: true, assigned_at: Time.current)
@@ -243,6 +246,14 @@ end
 
   def sync_completed_with_status
     self.completed = (status == "done")
+  end
+
+  def mirrored_origin_key?
+    origin_session_key.to_s.start_with?("hermes:", "wezbridge:")
+  end
+
+  def orchestration_projection?
+    origin_session_key.to_s.start_with?("wezbridge:")
   end
 
   # Track completion and archival timestamps.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < ApplicationRecord
   has_many :background_runs, dependent: :destroy
   has_many :task_templates, dependent: :destroy, inverse_of: :user
   has_many :api_tokens, dependent: :destroy, inverse_of: :user
+  has_many :orchestration_sources, dependent: :destroy, inverse_of: :user
+  has_many :orchestration_intents, dependent: :destroy, inverse_of: :user
   has_many :saved_links, dependent: :destroy, inverse_of: :user
   has_many :learning_proposals, dependent: :destroy, inverse_of: :user
   has_many :feed_entries, dependent: :destroy, inverse_of: :user

--- a/app/services/orchestration/payload_sanitizer.rb
+++ b/app/services/orchestration/payload_sanitizer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class PayloadSanitizer
+    SENSITIVE_KEY = /authorization|cookie|credential|environment|password|secret|token/i
+    BEARER_VALUE = /\bBearer\s+[A-Za-z0-9._~+\/=-]{12,}/i
+    ASSIGNMENT_VALUE = /\b(?:password|secret|token|api[_-]?key)\s*[:=]\s*\S+/i
+    MAX_STRING_LENGTH = 50_000
+
+    def self.call(value)
+      new.sanitize(value)
+    end
+
+    def self.text(value, maximum: MAX_STRING_LENGTH)
+      new.sanitize_text(value, maximum:)
+    end
+
+    def sanitize(value)
+      case value
+      when ActionController::Parameters then sanitize(value.to_unsafe_h)
+      when Hash then sanitize_hash(value)
+      when Array then value.first(500).map { |item| sanitize(item) }
+      when String then sanitize_text(value)
+      when Numeric, TrueClass, FalseClass, NilClass then value
+      else sanitize_text(value.to_s)
+      end
+    end
+
+    def sanitize_text(value, maximum: MAX_STRING_LENGTH)
+      value.to_s
+        .gsub(BEARER_VALUE, "Bearer [REDACTED]")
+        .gsub(ASSIGNMENT_VALUE, "[REDACTED]")
+        .truncate(maximum)
+    end
+
+    private
+
+    def sanitize_hash(value)
+      value.each_with_object({}) do |(key, item), result|
+        next if key.to_s.match?(SENSITIVE_KEY)
+
+        result[key.to_s] = sanitize(item)
+      end
+    end
+  end
+end

--- a/app/services/orchestration/sync_ingestor.rb
+++ b/app/services/orchestration/sync_ingestor.rb
@@ -1,0 +1,395 @@
+# frozen_string_literal: true
+
+module Orchestration
+  class InvalidRequest < StandardError; end
+
+  class SyncIngestor
+    DEFAULT_BOARD_ID = 5
+    IDENTIFIER_PATTERN = /\A[A-Za-z0-9._-]+\z/
+    SOURCE_STATES = %w[queued ready running review done blocked failed cancelled].freeze
+    BATCH_LIMITS = { tasks: 1_000, events: 500, messages: 200, intent_results: 100 }.freeze
+    STATUS_MAP = {
+      "queued" => :inbox,
+      "ready" => :up_next,
+      "running" => :in_progress,
+      "review" => :in_review,
+      "done" => :done,
+      "blocked" => :up_next,
+      "failed" => :in_review,
+      "cancelled" => :done
+    }.freeze
+
+    Result = Data.define(:source, :accepted, :intents)
+
+    def initialize(user)
+      @user = user
+    end
+
+    def sync(attributes)
+      attrs = attributes.with_indifferent_access
+      profile = valid_identifier(attrs[:profile], "profile", 64)
+      batches = extract_batches(attrs)
+      accepted = empty_counts
+
+      source = ApplicationRecord.transaction do
+        record = upsert_source(profile, attrs)
+        task_map = sync_tasks(record, batches[:tasks], accepted)
+        sync_dependencies(record, batches[:tasks], task_map)
+        sync_events(record, batches[:events], accepted)
+        sync_messages(record, batches[:messages], accepted)
+        sync_intent_results(record, batches[:intent_results], accepted)
+        record
+      end
+
+      Result.new(
+        source:,
+        accepted:,
+        intents: source.orchestration_intents.pending.limit(100).map(&:as_bridge_json)
+      )
+    end
+
+    private
+
+    attr_reader :user
+
+    def extract_batches(attributes)
+      BATCH_LIMITS.to_h do |name, limit|
+        values = Array(attributes[name])
+        raise InvalidRequest, "#{name} batch exceeds #{limit}" if values.length > limit
+        raise InvalidRequest, "#{name} must contain objects" unless values.all? { |item| item.respond_to?(:to_h) }
+
+        [name, values.map { |item| item.to_h.with_indifferent_access }]
+      end
+    end
+
+    def empty_counts
+      {
+        tasks: 0,
+        events: 0,
+        messages: 0,
+        intent_results: 0,
+        duplicates: 0
+      }
+    end
+
+    def upsert_source(profile, attributes)
+      source = user.orchestration_sources.find_or_initialize_by(profile:)
+      health = PayloadSanitizer.call(attributes[:health] || {})
+      source.update!(
+        status: normalize_source_status(health["status"]),
+        last_seen_at: Time.current,
+        generated_at: parse_time(attributes[:generated_at], allow_blank: true),
+        last_error: PayloadSanitizer.text(health["last_error"], maximum: 2_000).presence,
+        health:,
+        panes: PayloadSanitizer.call(attributes[:panes] || [])
+      )
+      source
+    end
+
+    def sync_tasks(source, snapshots, accepted)
+      snapshots.each_with_object({}) do |snapshot, task_map|
+        task = upsert_task(source, snapshot)
+        task_map[snapshot[:id].to_s] = task
+        accepted[:tasks] += 1
+      end
+    end
+
+    def upsert_task(source, snapshot)
+      ledger_id = valid_identifier(snapshot[:id], "task id", 80)
+      state = valid_state(snapshot[:state])
+      origin_key = task_origin_key(source.profile, ledger_id)
+      task = user.tasks.find_or_initialize_by(origin_session_key: origin_key)
+      new_record = task.new_record?
+
+      task.assign_attributes(task_attributes(source, snapshot, ledger_id, state, new_record))
+      task.description = required_text(snapshot[:brief] || snapshot[:goal], "brief", 2_000) if new_record
+      task.save!
+      sync_task_run(task, source, snapshot, ledger_id, state)
+      task
+    end
+
+    def task_attributes(source, snapshot, ledger_id, state, new_record)
+      {
+        board: new_record ? projection_board : nil,
+        name: required_text(snapshot[:title], "title", 500),
+        origin_session_id: ledger_id,
+        status: STATUS_MAP.fetch(state),
+        blocked: state == "blocked",
+        assigned_to_agent: false,
+        priority: normalize_priority(snapshot[:priority]),
+        error_at: state == "failed" ? parse_time(snapshot[:updated_at], allow_blank: true) || Time.current : nil,
+        error_message: state == "failed" ? PayloadSanitizer.text(snapshot[:blocker], maximum: 50_000).presence : nil,
+        tags: orchestration_tags(snapshot),
+        state_data: orchestration_state_data(source, snapshot, ledger_id, state)
+      }.compact
+    end
+
+    def orchestration_state_data(source, snapshot, ledger_id, state)
+      {
+        "orchestration" => PayloadSanitizer.call(
+          {
+            "profile" => source.profile,
+            "ledger_id" => ledger_id,
+            "source_state" => state,
+            "project" => snapshot[:project],
+            "kind" => snapshot[:kind],
+            "blocker" => snapshot[:blocker],
+            "next_action" => snapshot[:next_action],
+            "lease" => snapshot[:lease],
+            "acceptance" => snapshot[:acceptance],
+            "evidence" => snapshot[:evidence],
+            "source_updated_at" => snapshot[:updated_at]
+          }
+        )
+      }
+    end
+
+    def sync_task_run(task, source, snapshot, ledger_id, state)
+      attempt = Integer(snapshot[:attempt].presence || 0)
+      return if attempt <= 0
+
+      task_run = find_or_create_run(task, source, ledger_id, attempt)
+      task_run.update!(
+        summary: PayloadSanitizer.text(snapshot[:summary], maximum: 2_000).presence,
+        agent_output: PayloadSanitizer.text(snapshot[:outcome]).presence,
+        ended_at: terminal_state?(state) ? parse_time(snapshot[:updated_at], allow_blank: true) || Time.current : nil,
+        raw_payload: task_run.raw_payload.merge(
+          "source_state" => state,
+          "project" => PayloadSanitizer.text(snapshot[:project], maximum: 200)
+        )
+      )
+    rescue ArgumentError
+      raise InvalidRequest, "attempt is invalid"
+    end
+
+    def find_or_create_run(task, source, ledger_id, attempt)
+      external_key = "wezbridge:user-#{user.id}:#{source.profile}:#{ledger_id}:attempt:#{attempt}"
+      TaskRun.find_or_create_by!(external_source_key: external_key) do |run|
+        run.task = task
+        run.run_id = SecureRandom.uuid
+        run.run_number = next_run_number(task)
+        run.recommended_action = "in_review"
+        run.raw_payload = {
+          "source" => "wezbridge",
+          "profile" => source.profile,
+          "ledger_id" => ledger_id,
+          "attempt" => attempt
+        }
+      end
+    end
+
+    def sync_dependencies(source, snapshots, task_map)
+      snapshots.each do |snapshot|
+        task = task_map[snapshot[:id].to_s]
+        desired = Array(snapshot[:depends_on]).filter_map do |ledger_id|
+          user.tasks.find_by(origin_session_key: task_origin_key(source.profile, ledger_id.to_s))
+        end
+        sync_task_dependencies(task, desired)
+      end
+    end
+
+    def sync_task_dependencies(task, desired)
+      desired_ids = desired.map(&:id)
+      task.task_dependencies.where.not(depends_on_id: desired_ids).destroy_all
+      desired.each { |dependency| task.task_dependencies.find_or_create_by!(depends_on: dependency) }
+    end
+
+    def sync_events(source, events, accepted)
+      events.each do |event|
+        task = find_task!(source, event[:task_id])
+        run = run_for_event(task, source, event)
+        attributes = event_attributes(task, run, event)
+        if AgentActivityEvent.exists?(run_id: run.run_id, seq: attributes[:seq])
+          accepted[:duplicates] += 1
+        else
+          AgentActivityEvent.create!(attributes)
+          accepted[:events] += 1
+        end
+      rescue ActiveRecord::RecordNotUnique
+        accepted[:duplicates] += 1
+      end
+    end
+
+    def event_attributes(task, run, event)
+      {
+        task:,
+        run_id: run.run_id,
+        seq: positive_integer(event[:seq], "event seq"),
+        source: "wezbridge",
+        event_type: normalize_event_type(event[:event_type]),
+        level: normalize_level(event[:level]),
+        message: PayloadSanitizer.text(event[:message]),
+        payload: PayloadSanitizer.call(event[:payload] || {}).merge(
+          "external_id" => PayloadSanitizer.text(event[:external_id], maximum: 200)
+        ),
+        created_at: parse_time(event[:timestamp], allow_blank: true) || Time.current
+      }
+    end
+
+    def sync_messages(source, messages, accepted)
+      messages.each do |message|
+        task = find_task!(source, message[:task_id])
+        external_id = required_text(message[:external_id], "message external_id", 200)
+        if message_exists?(task, external_id)
+          accepted[:duplicates] += 1
+          next
+        end
+
+        task.agent_messages.create!(message_attributes(message, external_id))
+        accepted[:messages] += 1
+      end
+    end
+
+    def message_attributes(message, external_id)
+      provenance = message[:provenance].to_s
+      raise InvalidRequest, "message provenance is invalid" unless %w[operator orchestrator worker].include?(provenance)
+
+      {
+        direction: provenance == "operator" ? "outgoing" : "incoming",
+        message_type: normalize_message_type(message[:message_type]),
+        content: required_text(PayloadSanitizer.text(message[:content]), "message content", 100_000),
+        sender_name: PayloadSanitizer.text(message[:sender_name], maximum: 100).presence || provenance.titleize,
+        metadata: {
+          "external_id" => external_id,
+          "provenance" => provenance,
+          "source" => "wezbridge",
+          "source_timestamp" => message[:timestamp]
+        }
+      }
+    end
+
+    def sync_intent_results(source, results, accepted)
+      results.each do |item|
+        intent = user.orchestration_intents.find_by!(id: item[:id], orchestration_source: source)
+        status = item[:status].to_s
+        raise InvalidRequest, "intent result status is invalid" unless %w[applied rejected].include?(status)
+
+        if intent.status != "pending"
+          accepted[:duplicates] += 1
+          next
+        end
+
+        result = PayloadSanitizer.call(item[:result] || {})
+        intent.update!(status:, result:, processed_at: Time.current, task: result_task(source, result) || intent.task)
+        accepted[:intent_results] += 1
+      end
+    end
+
+    def result_task(source, result)
+      origin_key = result["task_origin_key"].presence
+      origin_key ||= task_origin_key(source.profile, result["ledger_id"]) if result["ledger_id"].present?
+      origin_key ||= task_origin_key(source.profile, result["task_id"]) if result["task_id"].present?
+      user.tasks.find_by(origin_session_key: origin_key) if origin_key.present?
+    end
+
+    def projection_board
+      board = user.boards.find_by(id: DEFAULT_BOARD_ID)
+      raise InvalidRequest, "Board #{DEFAULT_BOARD_ID} is unavailable" unless board
+      raise InvalidRequest, "The ALL aggregator cannot receive mirrored work" if board.aggregator?
+
+      board
+    end
+
+    def find_task!(source, ledger_id)
+      user.tasks.find_by!(origin_session_key: task_origin_key(source.profile, ledger_id.to_s))
+    end
+
+    def run_for_event(task, source, event)
+      attempt = positive_integer(event[:attempt].presence || 1, "event attempt")
+      ledger_id = task.origin_session_id
+      find_or_create_run(task, source, ledger_id, attempt)
+    end
+
+    def message_exists?(task, external_id)
+      task.agent_messages.where("metadata ->> 'external_id' = ?", external_id).exists?
+    end
+
+    def normalize_source_status(value)
+      status = value.to_s
+      OrchestrationSource::STATUSES.include?(status) ? status : "healthy"
+    end
+
+    def normalize_priority(value)
+      case value.to_s
+      when "3", "high", "urgent", "p0", "p1" then :high
+      when "2", "medium", "normal", "p2" then :medium
+      when "1", "low", "p3" then :low
+      else :none
+      end
+    end
+
+    def normalize_event_type(value)
+      type = value.to_s
+      AgentActivityEvent::EVENT_TYPES.include?(type) ? type : "status"
+    end
+
+    def normalize_level(value)
+      level = value.to_s
+      AgentActivityEvent::LEVELS.include?(level) ? level : "info"
+    end
+
+    def normalize_message_type(value)
+      case value.to_s
+      when "result", "output" then "output"
+      when "error" then "error"
+      else "feedback"
+      end
+    end
+
+    def orchestration_tags(snapshot)
+      ["orchestration", PayloadSanitizer.text(snapshot[:project], maximum: 100).presence].compact
+    end
+
+    def task_origin_key(profile, ledger_id)
+      "wezbridge:#{profile}:task:#{valid_identifier(ledger_id, 'task id', 80)}"
+    end
+
+    def valid_identifier(value, field, maximum)
+      identifier = value.to_s
+      valid = identifier.present? && identifier.length <= maximum && identifier.match?(IDENTIFIER_PATTERN)
+      raise InvalidRequest, "#{field} is invalid" unless valid
+
+      identifier
+    end
+
+    def valid_state(value)
+      state = value.to_s
+      raise InvalidRequest, "task state is invalid" unless SOURCE_STATES.include?(state)
+
+      state
+    end
+
+    def required_text(value, field, maximum)
+      text = value.to_s.strip
+      raise InvalidRequest, "#{field} is required" if text.blank?
+      raise InvalidRequest, "#{field} is too long" if text.length > maximum
+
+      text
+    end
+
+    def parse_time(value, allow_blank: false)
+      return if allow_blank && value.blank?
+
+      Time.iso8601(value.to_s)
+    rescue ArgumentError
+      raise InvalidRequest, "timestamp is invalid"
+    end
+
+    def positive_integer(value, field)
+      integer = Integer(value)
+      raise InvalidRequest, "#{field} is invalid" unless integer.positive?
+
+      integer
+    rescue ArgumentError, TypeError
+      raise InvalidRequest, "#{field} is invalid"
+    end
+
+    def terminal_state?(state)
+      %w[done failed cancelled].include?(state)
+    end
+
+    def next_run_number(task)
+      (task.task_runs.maximum(:run_number) || 0) + 1
+    end
+  end
+end

--- a/app/views/control_room/_task_list.html.erb
+++ b/app/views/control_room/_task_list.html.erb
@@ -1,0 +1,21 @@
+<section class="min-h-40 rounded-xl border border-border bg-bg-surface p-4">
+  <div class="flex items-center justify-between gap-2">
+    <h2 class="text-sm font-semibold text-content"><%= title %></h2>
+    <span class="rounded-full bg-bg-elevated px-2 py-0.5 text-xs text-content-muted"><%= tasks.length %></span>
+  </div>
+  <div class="mt-3 space-y-2">
+    <% tasks.first(20).each do |task| %>
+      <% state = task.state_data.fetch("orchestration", {}) %>
+      <%= link_to control_room_path(task_id: task.id), class: "block rounded-lg border border-border bg-bg-elevated p-3 transition-colors hover:border-accent/40" do %>
+        <p class="truncate text-sm font-medium text-content"><%= task.name %></p>
+        <div class="mt-1 flex items-center justify-between gap-2 text-xs text-content-muted">
+          <span class="truncate"><%= state["project"] %></span>
+          <span><%= state["source_state"] %></span>
+        </div>
+      <% end %>
+    <% end %>
+    <% if tasks.empty? %>
+      <p class="py-4 text-center text-xs text-content-muted">Nothing here.</p>
+    <% end %>
+  </div>
+</section>

--- a/app/views/control_room/show.html.erb
+++ b/app/views/control_room/show.html.erb
@@ -1,0 +1,181 @@
+<% content_for :title, "Control Room" %>
+<% content_for :breadcrumb_standalone, "Control Room" %>
+
+<div class="py-8 space-y-6">
+  <header class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+    <div>
+      <p class="text-xs font-semibold uppercase tracking-[0.2em] text-accent">Personal orchestration</p>
+      <h1 class="mt-1 text-3xl font-semibold text-content font-display">Control Room</h1>
+      <p class="mt-2 max-w-2xl text-sm text-content-secondary">
+        Create work, talk to the orchestrator, and watch the local fleet without managing every terminal tab.
+      </p>
+    </div>
+
+    <div class="flex flex-wrap gap-2">
+      <% if @sources.any? %>
+        <% @sources.each do |source| %>
+          <% status_class = source.stale? ? "text-yellow-400 border-yellow-400/30 bg-yellow-400/10" : "text-green-400 border-green-400/30 bg-green-400/10" %>
+          <%= link_to control_room_path(source_id: source.id),
+                class: "rounded-lg border px-3 py-2 text-xs #{status_class}" do %>
+            <span class="font-semibold"><%= source.profile %></span>
+            <span class="ml-1"><%= source.display_status %></span>
+            <% if source.last_seen_at %>
+              <span class="ml-1 text-content-muted"><%= time_ago_in_words(source.last_seen_at) %> ago</span>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <span class="rounded-lg border border-yellow-400/30 bg-yellow-400/10 px-3 py-2 text-xs text-yellow-400">
+          Waiting for the Wezbridge bridge
+        </span>
+      <% end %>
+    </div>
+  </header>
+
+  <section class="rounded-xl border border-border bg-bg-surface p-4">
+    <div class="flex items-center justify-between gap-3">
+      <div>
+        <h2 class="text-sm font-semibold text-content">Fleet</h2>
+        <p class="mt-1 text-xs text-content-muted">
+          <% if @source&.last_seen_at %>
+            <%= @source.panes.length %> visible panes · last sync <%= time_ago_in_words(@source.last_seen_at) %> ago
+          <% else %>
+            No bridge telemetry yet
+          <% end %>
+        </p>
+      </div>
+      <% if @source&.health&.dig("fleet") %>
+        <span class="text-xs text-content-muted">
+          <%= @source.health.dig("fleet", "a2a_envelopes").to_i %> recent A2A events
+        </span>
+      <% end %>
+    </div>
+    <% if @source&.panes&.any? %>
+      <div class="mt-3 flex flex-wrap gap-2">
+        <% @source.panes.each do |pane| %>
+          <span class="rounded-lg border border-border bg-bg-elevated px-3 py-2 text-xs text-content-secondary">
+            pane <%= pane["pane_id"] || pane["id"] %>
+            <span class="ml-1 text-content-muted"><%= pane["project"] %> · <%= pane["status"] %></span>
+          </span>
+        <% end %>
+      </div>
+    <% end %>
+  </section>
+
+  <section class="grid gap-4 lg:grid-cols-2">
+    <div class="rounded-xl border border-border bg-bg-surface p-5">
+      <h2 class="text-lg font-semibold text-content">New Task</h2>
+      <p class="mt-1 text-xs text-content-muted">Safe work starts automatically after the local contract accepts it.</p>
+      <%= form_with url: control_room_tasks_path, class: "mt-4 grid gap-3" do |form| %>
+        <%= form.hidden_field :source_id, value: @source&.id %>
+        <%= form.label :project, "Project", class: "sr-only" %>
+        <%= form.text_field :project, required: true, placeholder: "Project, e.g. whatsappbot",
+              class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+        <%= form.label :title, "Task title", class: "sr-only" %>
+        <%= form.text_field :title, placeholder: "Task title",
+              class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+        <%= form.label :brief, "Task brief", class: "sr-only" %>
+        <%= form.text_area :brief, required: true, rows: 4, placeholder: "What should be done?",
+              class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+        <%= form.label :acceptance, "Acceptance criteria", class: "sr-only" %>
+        <%= form.text_area :acceptance, rows: 2, placeholder: "What does done look like?",
+              class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+        <div class="flex items-center justify-between gap-3">
+          <%= form.label :priority, "Priority", class: "sr-only" %>
+          <%= form.select :priority, [["Normal", "normal"], ["High", "high"], ["Low", "low"]], {},
+                class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+          <%= form.submit "Create task", disabled: @source.blank?,
+                class: "cursor-pointer rounded-lg bg-accent px-4 py-2 font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40" %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="rounded-xl border border-border bg-bg-surface p-5">
+      <h2 class="text-lg font-semibold text-content">Ask Orchestrator</h2>
+      <p class="mt-1 text-xs text-content-muted">Pane 0 answers in the task thread; the terminal remains optional.</p>
+      <%= form_with url: control_room_ask_path, class: "mt-4 grid gap-3" do |form| %>
+        <%= form.hidden_field :source_id, value: @source&.id %>
+        <%= form.label :project, "Question project", class: "sr-only" %>
+        <%= form.text_field :project, required: true, placeholder: "Project or topic",
+              class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+        <%= form.label :title, "Question title", class: "sr-only" %>
+        <%= form.text_field :title, placeholder: "Question title",
+              class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+        <%= form.label :brief, "Question", class: "sr-only" %>
+        <%= form.text_area :brief, required: true, rows: 5, placeholder: "What do you want to discuss?",
+              class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+        <div class="flex justify-end">
+          <%= form.submit "Ask", disabled: @source.blank?,
+                class: "cursor-pointer rounded-lg bg-accent px-4 py-2 font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40" %>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+  <% if @pending_intents.any? %>
+    <section class="rounded-xl border border-accent/30 bg-accent/5 p-4">
+      <h2 class="text-sm font-semibold text-content">Queued requests</h2>
+      <div class="mt-2 flex flex-wrap gap-2">
+        <% @pending_intents.each do |intent| %>
+          <span class="rounded-md border border-accent/20 bg-bg-elevated px-2 py-1 text-xs text-content-secondary">
+            #<%= intent.id %> <%= intent.kind.humanize %>
+          </span>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+
+  <section class="grid gap-4 xl:grid-cols-4">
+    <%= render "task_list", title: "Needs Attention", tasks: @needs_attention, tone: "yellow" %>
+    <%= render "task_list", title: "Active Work", tasks: @active, tone: "blue" %>
+    <%= render "task_list", title: "Failures", tasks: @failures, tone: "red" %>
+    <%= render "task_list", title: "Recently Completed", tasks: @recent, tone: "green" %>
+  </section>
+
+  <% if @selected_task %>
+    <% state = @selected_task.state_data.fetch("orchestration", {}) %>
+    <section id="task-thread" class="rounded-xl border border-border bg-bg-surface p-5">
+      <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p class="text-xs uppercase tracking-wider text-content-muted"><%= state["project"] %> · <%= state["source_state"] %></p>
+          <h2 class="mt-1 text-xl font-semibold text-content"><%= @selected_task.name %></h2>
+          <p class="mt-2 whitespace-pre-wrap text-sm text-content-secondary"><%= @selected_task.description %></p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <% if @selected_task.blocked? || state["source_state"] == "review" %>
+            <%= button_to "Approve", approve_control_room_task_path(@selected_task), class: "rounded-lg bg-green-600 px-3 py-2 text-xs font-semibold text-white" %>
+          <% end %>
+          <% if state["source_state"] == "failed" %>
+            <%= button_to "Retry", retry_control_room_task_path(@selected_task), class: "rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white" %>
+          <% end %>
+          <% unless %w[done cancelled].include?(state["source_state"]) %>
+            <%= button_to "Cancel", cancel_control_room_task_path(@selected_task), class: "rounded-lg border border-red-500/40 px-3 py-2 text-xs font-semibold text-red-400" %>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="mt-5 space-y-3">
+        <% @selected_task.agent_messages.sort_by(&:created_at).each do |message| %>
+          <% operator = message.metadata["provenance"] == "operator" %>
+          <article class="rounded-lg border border-border p-3 <%= operator ? "ml-8 bg-accent/5" : "mr-8 bg-bg-elevated" %>">
+            <div class="flex items-center justify-between gap-3 text-xs">
+              <span class="font-semibold text-content"><%= operator ? "You" : message.display_sender %></span>
+              <span class="text-content-muted"><%= message.created_at.strftime("%Y-%m-%d %H:%M") %></span>
+            </div>
+            <p class="mt-2 whitespace-pre-wrap text-sm text-content-secondary"><%= message.content %></p>
+          </article>
+        <% end %>
+        <% if @selected_task.agent_messages.empty? %>
+          <p class="text-sm text-content-muted">No messages yet.</p>
+        <% end %>
+      </div>
+
+      <%= form_with url: control_room_task_messages_path(@selected_task), class: "mt-5 flex gap-3" do |form| %>
+        <%= form.label :content, "Reply", class: "sr-only" %>
+        <%= form.text_area :content, required: true, rows: 2, placeholder: "Reply to the orchestrator…",
+              class: "min-w-0 flex-1 rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+        <%= form.submit "Send", class: "cursor-pointer self-end rounded-lg bg-accent px-4 py-2 font-semibold text-white" %>
+      <% end %>
+    </section>
+  <% end %>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -341,6 +341,38 @@
     paths are intentionally unavailable in Safe-LAN mode.
   </p>
 </div>
+
+<div class="bg-bg-surface border border-border rounded-lg p-5 space-y-4">
+  <div>
+    <h3 class="text-sm font-semibold text-content font-display">Wezbridge control plane</h3>
+    <p class="mt-1 text-xs text-content-secondary">
+      A dedicated scoped token lets the PC push the disposable task projection
+      and poll operator intents. It cannot call legacy execution routes.
+    </p>
+  </div>
+
+  <% if flash[:new_orchestration_token].present? %>
+    <div class="rounded-lg border border-yellow-400/30 bg-yellow-400/10 p-3">
+      <p class="text-xs font-semibold text-yellow-300">Copy this token now. It will not be shown again.</p>
+      <code class="mt-2 block break-all select-all text-xs text-content"><%= flash[:new_orchestration_token] %></code>
+    </div>
+  <% end %>
+
+  <% if @orchestration_token %>
+    <div class="flex items-center justify-between gap-3 rounded-lg bg-bg-elevated p-3">
+      <div>
+        <p class="text-sm font-medium text-content">Active</p>
+        <p class="text-xs text-content-muted"><%= @orchestration_token.masked_token %></p>
+      </div>
+      <%= button_to "Revoke", revoke_orchestration_token_settings_path,
+            method: :delete,
+            class: "rounded-md border border-red-500/40 px-3 py-1.5 text-xs font-semibold text-red-400" %>
+    </div>
+  <% else %>
+    <%= button_to "Create bridge token", create_orchestration_token_settings_path,
+          class: "rounded-md bg-accent px-3 py-2 text-xs font-semibold text-white" %>
+  <% end %>
+</div>
   </div>
 
   <!-- Notifications Tab -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
         post "hermes/completions", to: "hermes#completions"
       end
 
+      post "orchestration/sync", to: "orchestration#sync"
+
       resources :audits, only: [] do
         collection do
           post :ingest
@@ -249,9 +251,19 @@ Rails.application.routes.draw do
   resources :passwords, param: :token
   resource :settings, only: [ :show, :update ], controller: "profiles" do
     post :regenerate_api_token
+    post :create_orchestration_token
+    delete :revoke_orchestration_token
     post :test_connection
     post :test_notification
   end
+
+  get "control-room", to: "control_room#show", as: :control_room
+  post "control-room/tasks", to: "control_room#create_task", as: :control_room_tasks
+  post "control-room/ask", to: "control_room#ask", as: :control_room_ask
+  post "control-room/tasks/:task_id/messages", to: "control_room#message", as: :control_room_task_messages
+  post "control-room/tasks/:task_id/approve", to: "control_room#approve", as: :approve_control_room_task
+  post "control-room/tasks/:task_id/retry", to: "control_room#retry", as: :retry_control_room_task
+  post "control-room/tasks/:task_id/cancel", to: "control_room#cancel", as: :cancel_control_room_task
 
   # Link Inbox
   resources :saved_links, only: [:index, :create, :update, :destroy] do

--- a/db/migrate/20260727223000_add_orchestration_control_plane.rb
+++ b/db/migrate/20260727223000_add_orchestration_control_plane.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class AddOrchestrationControlPlane < ActiveRecord::Migration[8.1]
+  def change
+    create_table :orchestration_sources do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :profile, null: false
+      t.string :status, null: false, default: "stale"
+      t.datetime :last_seen_at
+      t.datetime :generated_at
+      t.text :last_error
+      t.jsonb :health, null: false, default: {}
+      t.jsonb :panes, null: false, default: []
+      t.timestamps
+    end
+    add_index :orchestration_sources, %i[user_id profile], unique: true
+    add_index :orchestration_sources, :last_seen_at
+
+    create_table :orchestration_intents do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :orchestration_source, null: false, foreign_key: true
+      t.references :task, null: true, foreign_key: { on_delete: :nullify }
+      t.string :kind, null: false
+      t.string :status, null: false, default: "pending"
+      t.jsonb :payload, null: false, default: {}
+      t.jsonb :result, null: false, default: {}
+      t.datetime :processed_at
+      t.timestamps
+    end
+    add_index :orchestration_intents,
+      %i[orchestration_source_id status id],
+      name: "idx_orchestration_intents_source_status"
+
+    add_index :tasks, %i[user_id origin_session_key],
+      unique: true,
+      name: "idx_tasks_user_wezbridge_origin_key",
+      where: "origin_session_key LIKE 'wezbridge:%'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_27_030000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_27_223000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -675,6 +675,39 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_030000) do
     t.index ["user_id"], name: "index_openclaw_integration_statuses_on_user_id", unique: true
   end
 
+  create_table "orchestration_intents", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "kind", null: false
+    t.bigint "orchestration_source_id", null: false
+    t.jsonb "payload", default: {}, null: false
+    t.datetime "processed_at"
+    t.jsonb "result", default: {}, null: false
+    t.string "status", default: "pending", null: false
+    t.bigint "task_id"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["orchestration_source_id", "status", "id"], name: "idx_orchestration_intents_source_status"
+    t.index ["orchestration_source_id"], name: "index_orchestration_intents_on_orchestration_source_id"
+    t.index ["task_id"], name: "index_orchestration_intents_on_task_id"
+    t.index ["user_id"], name: "index_orchestration_intents_on_user_id"
+  end
+
+  create_table "orchestration_sources", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "generated_at"
+    t.jsonb "health", default: {}, null: false
+    t.text "last_error"
+    t.datetime "last_seen_at"
+    t.jsonb "panes", default: [], null: false
+    t.string "profile", null: false
+    t.string "status", default: "stale", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["last_seen_at"], name: "index_orchestration_sources_on_last_seen_at"
+    t.index ["user_id", "profile"], name: "index_orchestration_sources_on_user_id_and_profile", unique: true
+    t.index ["user_id"], name: "index_orchestration_sources_on_user_id"
+  end
+
   create_table "runner_leases", force: :cascade do |t|
     t.string "agent_name"
     t.datetime "created_at", null: false
@@ -1097,6 +1130,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_030000) do
     t.index ["user_id", "assigned_to_agent", "status"], name: "index_tasks_on_user_agent_status"
     t.index ["user_id", "completed", "completed_at"], name: "idx_tasks_user_completed"
     t.index ["user_id", "origin_session_key"], name: "idx_tasks_user_hermes_origin_key", unique: true, where: "((origin_session_key)::text ~~ 'hermes:%'::text)"
+    t.index ["user_id", "origin_session_key"], name: "idx_tasks_user_wezbridge_origin_key", unique: true, where: "((origin_session_key)::text ~~ 'wezbridge:%'::text)"
     t.index ["user_id", "priority", "position"], name: "idx_tasks_auto_runner_candidates", where: "((status = 1) AND (blocked = false) AND (agent_claimed_at IS NULL) AND (agent_session_id IS NULL) AND (agent_session_key IS NULL) AND (assigned_to_agent = true) AND (auto_pull_blocked = false))"
     t.index ["user_id", "status"], name: "index_tasks_on_user_status"
     t.index ["user_id"], name: "index_tasks_on_user_id"
@@ -1257,6 +1291,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_030000) do
   add_foreign_key "openclaw_flows", "tasks"
   add_foreign_key "openclaw_flows", "users"
   add_foreign_key "openclaw_integration_statuses", "users"
+  add_foreign_key "orchestration_intents", "orchestration_sources"
+  add_foreign_key "orchestration_intents", "tasks", on_delete: :nullify
+  add_foreign_key "orchestration_intents", "users"
+  add_foreign_key "orchestration_sources", "users"
   add_foreign_key "runner_leases", "tasks"
   add_foreign_key "saved_links", "users"
   add_foreign_key "sessions", "users"

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,10 +1,65 @@
 # ClawTrol API Reference
+<!-- CURRENT only for task-board, passive mirror, and orchestration sync endpoints. -->
+<!-- Covers request authentication, task APIs, and outbound bridge synchronization. -->
+<!-- Key terms: bearer scope, orchestration_bridge:sync, disposable projection, intent. -->
+<!-- Read before integrating a private-LAN client; legacy execution sections are non-authoritative. -->
+<!-- Base URL: /api/v1. Authentication: Authorization: Bearer YOUR_TOKEN. -->
+<!-- Updated: 2026-07-27. -->
 
-Complete API endpoint documentation for ClawTrol.
+## Wezbridge orchestration sync
 
-**Base URL:** `/api/v1`
+```http
+POST /orchestration/sync
+Authorization: Bearer <scoped-token>
+Content-Type: application/json
+```
 
-**Authentication:** `Authorization: Bearer YOUR_TOKEN`
+Requires the `orchestration_bridge:sync` scope. The Windows bridge initiates
+this request; ClawTrol never opens an inbound connection to the PC.
+
+The request accepts `profile`, `generated_at`, source `health`, `panes`, task
+snapshots, task-scoped `events`, provenance-tagged `messages`, and
+`intent_results`. Arrays may be omitted on poll-only calls.
+
+```json
+{
+  "profile": "primary",
+  "generated_at": "2026-07-27T20:00:00Z",
+  "health": { "status": "healthy" },
+  "panes": [],
+  "tasks": [],
+  "events": [],
+  "messages": [],
+  "intent_results": []
+}
+```
+
+ClawTrol returns accepted counts and pending operator intents. Pending intents
+are returned again until the bridge reports an `applied` or `rejected` result.
+
+```json
+{
+  "server_time": "2026-07-27T20:00:01Z",
+  "source": {
+    "id": 1,
+    "profile": "primary",
+    "status": "healthy",
+    "last_seen_at": "2026-07-27T20:00:01Z"
+  },
+  "accepted": {
+    "tasks": 0,
+    "events": 0,
+    "messages": 0,
+    "intent_results": 0,
+    "duplicates": 0
+  },
+  "intents": []
+}
+```
+
+The v1 intent allowlist is `create_task`, `message`, `approve`, `retry`, and
+`cancel`. All state changes remain subject to the local ledger FSM and gate
+contracts.
 
 **Agent Headers (recommended):**
 ```

--- a/docs/DOCS-MAP.md
+++ b/docs/DOCS-MAP.md
@@ -4,7 +4,7 @@
 <!-- Read this map before any documentation body; never execute a superseded runbook or roadmap. -->
 <!-- CURRENT means authoritative only for the scope stated in its row, not a blanket release verdict. -->
 <!-- The recovered Docker topology is current; systemd and source-pull deployment instructions are superseded. -->
-<!-- Updated: 2026-07-27 after closing R1-R3 and dropping GitHub hidden-ref cleanup. -->
+<!-- Updated: 2026-07-27 with the personal control-room implementation contract. -->
 
 ## Current sources
 
@@ -16,6 +16,7 @@
 | `docs/reports/safe-lan-remediation-r0-2026-07-26.md` | CURRENT | Latest active-database, container, stopped-service, and health anchors. |
 | `docs/reports/safe-lan-remediation-r1-r4-2026-07-27.md` | CURRENT | Credential cutover, immutable deployment, closed R1-R3 evidence, and remaining passive-mirror gates. |
 | `docs/reports/hermes-delta-review-2026-07-26.md` | CURRENT | Passive-mirror boundary and pinned Hermes compatibility evidence. |
+| `docs/plans/CLAWTROL-WEZBRIDGE-CONTROL-PLANE.md` | CURRENT | ClawTrol cockpit, outbound Wezbridge sync, operator intents, supervision, and exact-revision delivery contract. |
 | `Dockerfile` and `docker-compose.yml` | CURRENT | Exact-SHA image and one-web-container deployment topology. |
 | `.claude/skills/deploy-to-vm/SKILL.md` | CURRENT | Immutable release procedure and rollback gate. |
 | `.claude/rules/local-first-workflow.md` | CURRENT | Local edit and immutable delivery policy. |

--- a/docs/plans/CLAWTROL-WEZBRIDGE-CONTROL-PLANE.md
+++ b/docs/plans/CLAWTROL-WEZBRIDGE-CONTROL-PLANE.md
@@ -1,0 +1,51 @@
+# ClawTrol + Wezbridge Personal Control Room
+<!-- CURRENT: implementation contract for the personal-LAN orchestration cockpit. -->
+<!-- Covers: Control Room UX, outbound sync, task intents, pane supervision, deployment evidence. -->
+<!-- Key terms: disposable projection, single ledger writer, operator intent, exact tested SHA. -->
+<!-- Read when changing ClawTrol orchestration UI/API or the Wezbridge bridge/kernel. -->
+<!-- `_intel` remains authoritative; ClawTrol never owns pane or executor credentials. -->
+<!-- Updated: 2026-07-27. -->
+
+## Operating model
+
+ClawTrol is the operator-facing cockpit and a disposable projection of Wezbridge
+state. The Wezbridge daemon on the Windows PC is the single ledger writer and
+retains all pane, terminal, and local credential authority. The PC initiates
+every network request; ClawTrol never opens an inbound connection to it.
+
+The operator creates tasks, asks questions, replies to workers, and handles
+blocked work from `/control-room`. Pane 0 remains the replaceable reasoning
+client but normally speaks through task-scoped messages in ClawTrol.
+
+## V1 contract
+
+- One scoped endpoint: `POST /api/v1/orchestration/sync`.
+- One bridge scope: `orchestration_bridge:sync`.
+- One task key: `wezbridge:<profile>:task:<ledger-id>`.
+- Five operator intents: `create_task`, `message`, `approve`, `retry`, `cancel`.
+- Two new records: orchestration sources and orchestration intents.
+- Existing Task, TaskRun, AgentActivityEvent, AgentMessage, and TaskDependency
+  records remain the projection primitives.
+- Source events use rotation-safe file identities and byte cursors. Event
+  application remains idempotent through each run's stable positive sequence.
+- Task creation always passes through Wezbridge `contractFor()` rules. Gated
+  work is born blocked and cannot be pre-approved by ClawTrol.
+
+## Delivery and safety
+
+Completed code work runs its project gates, commits, pushes the current branch,
+deploys the exact tested revision, and verifies the live route. Failed live
+smokes restore the previous deployment. Destructive data changes, credential
+rotation, purchases, external messages, and scope expansion remain operator
+gates.
+
+No Rails agent, inbound PC port, arbitrary pane command, direct Hermes control,
+OpenClaw, Factory, Nightshift, ZeroBitch, Paperclip, or legacy worker is part of
+this design.
+
+## Acceptance
+
+The first canary is `whatsappbot`. It must prove mirror fidelity and rebuild,
+stale detection, task conversation, pane-0 recovery in under two minutes,
+exactly-once intent replay, exact-revision deployment, and live smoke evidence
+before non-archived fleet projects are enabled.

--- a/test/controllers/api/v1/orchestration_controller_test.rb
+++ b/test/controllers/api/v1/orchestration_controller_test.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::OrchestrationControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @board = Board.create!(id: 5, user: @user, name: "Orchestration", position: 50)
+    @token = @user.api_tokens.create!(
+      name: "Wezbridge",
+      scopes: ["orchestration_bridge:sync"]
+    )
+    @headers = {
+      "Authorization" => "Bearer #{@token.raw_token}",
+      "Content-Type" => "application/json"
+    }
+  end
+
+  test "requires a live token with orchestration scope" do
+    post sync_path, params: base_payload.to_json, headers: { "Content-Type" => "application/json" }
+    assert_response :unauthorized
+
+    unscoped = @user.api_tokens.create!(name: "Unscoped")
+    post sync_path, params: base_payload.to_json, headers: bearer_headers(unscoped.raw_token)
+    assert_response :forbidden
+
+    @token.revoke!
+    post sync_path, params: base_payload.to_json, headers: @headers
+    assert_response :unauthorized
+  end
+
+  test "upserts task run event and reply idempotently without changing brief" do
+    payload = base_payload.merge(
+      tasks: [task_snapshot],
+      events: [event_snapshot],
+      messages: [message_snapshot]
+    )
+
+    post sync_path, params: payload.to_json, headers: @headers
+    assert_response :success
+    task = @user.tasks.find_by!(origin_session_key: "wezbridge:primary:task:T-0001")
+    run = task.task_runs.find_by!(external_source_key: external_run_key)
+
+    assert_equal 5, task.board_id
+    assert_equal "Original brief", task.description
+    assert_equal "in_progress", task.status
+    refute task.assigned_to_agent?
+    assert_equal "running", task.state_data.dig("orchestration", "source_state")
+    source = @user.orchestration_sources.find_by!(profile: "primary")
+    assert_equal "healthy", source.status
+    refute source.health.key?("token")
+    assert_equal 1, run.run_number
+    assert_equal 1, task.agent_activity_events.count
+    event = task.agent_activity_events.first
+    assert_equal 1_000_000_000_043, event.seq
+    refute event.payload.key?("authorization")
+    assert_equal 1, task.agent_messages.count
+
+    replay = payload.deep_dup
+    replay[:tasks][0][:brief] = "Attempted rewrite"
+    replay[:tasks][0][:title] = "Updated title"
+    post sync_path, params: replay.to_json, headers: @headers
+    assert_response :success
+
+    assert_equal "Original brief", task.reload.description
+    assert_equal "Updated title", task.name
+    assert_equal 1, task.task_runs.count
+    assert_equal 1, task.agent_activity_events.count
+    assert_equal 1, task.agent_messages.count
+    assert_equal 2, response.parsed_body.dig("accepted", "duplicates")
+  end
+
+  test "returns pending intents until an applied result is received" do
+    post sync_path, params: base_payload.merge(tasks: [task_snapshot]).to_json, headers: @headers
+    source = @user.orchestration_sources.find_by!(profile: "primary")
+    task = @user.tasks.find_by!(origin_session_key: "wezbridge:primary:task:T-0001")
+    intent = @user.orchestration_intents.create!(
+      orchestration_source: source,
+      task:,
+      kind: "approve",
+      payload: {}
+    )
+
+    post sync_path, params: base_payload.to_json, headers: @headers
+    assert_equal [intent.id], response.parsed_body["intents"].pluck("id")
+
+    result = { id: intent.id, status: "applied", result: { ledger_id: "T-0001" } }
+    post sync_path, params: base_payload.merge(intent_results: [result]).to_json, headers: @headers
+    assert_response :success
+    assert_equal "applied", intent.reload.status
+    assert_equal [], response.parsed_body["intents"]
+
+    post sync_path, params: base_payload.merge(intent_results: [result]).to_json, headers: @headers
+    assert_response :success
+    assert_equal 1, response.parsed_body.dig("accepted", "duplicates")
+  end
+
+  test "keeps profiles isolated by authenticated user" do
+    post sync_path, params: base_payload.merge(tasks: [task_snapshot]).to_json, headers: @headers
+
+    other_user = users(:two)
+    Board.create!(id: 15, user: other_user, name: "Other projection", position: 50)
+    other_token = other_user.api_tokens.create!(
+      name: "Other bridge",
+      scopes: ["orchestration_bridge:sync"]
+    )
+    other_payload = base_payload.merge(tasks: [task_snapshot.merge(id: "T-9999")])
+    other_payload[:tasks][0][:board_id] = 15
+
+    post sync_path, params: other_payload.to_json, headers: bearer_headers(other_token.raw_token)
+    assert_response :unprocessable_entity
+    assert_equal 1, @user.tasks.where("origin_session_key LIKE 'wezbridge:%'").count
+    assert_equal 0, other_user.tasks.where("origin_session_key LIKE 'wezbridge:%'").count
+  end
+
+  private
+
+  def sync_path
+    "/api/v1/orchestration/sync"
+  end
+
+  def base_payload
+    {
+      profile: "primary",
+      generated_at: "2026-07-27T20:00:00Z",
+      health: { status: "ok", last_error: nil, token: "must-be-dropped" },
+      panes: [{ id: 0, state: "idle" }],
+      tasks: [],
+      events: [],
+      messages: [],
+      intent_results: []
+    }
+  end
+
+  def task_snapshot
+    {
+      id: "T-0001",
+      title: "Mirrored task",
+      brief: "Original brief",
+      project: "whatsappbot",
+      kind: "task",
+      state: "running",
+      priority: "high",
+      attempt: 1,
+      depends_on: [],
+      acceptance: ["focused tests pass"],
+      evidence: [],
+      updated_at: "2026-07-27T20:00:05Z"
+    }
+  end
+
+  def event_snapshot
+    {
+      external_id: "events-v1:42",
+      task_id: "T-0001",
+      attempt: 1,
+      seq: 1_000_000_000_043,
+      timestamp: "2026-07-27T20:00:06Z",
+      event_type: "status",
+      level: "info",
+      message: "Working",
+      payload: { authorization: "must-be-dropped" }
+    }
+  end
+
+  def message_snapshot
+    {
+      external_id: "messages-v1:12",
+      task_id: "T-0001",
+      provenance: "orchestrator",
+      message_type: "progress",
+      content: "Started the task",
+      sender_name: "Pane 0",
+      timestamp: "2026-07-27T20:00:07Z"
+    }
+  end
+
+  def external_run_key
+    "wezbridge:user-#{@user.id}:primary:T-0001:attempt:1"
+  end
+
+  def bearer_headers(token)
+    {
+      "Authorization" => "Bearer #{token}",
+      "Content-Type" => "application/json"
+    }
+  end
+end

--- a/test/controllers/control_room_controller_test.rb
+++ b/test/controllers/control_room_controller_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ControlRoomControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @source = @user.orchestration_sources.create!(
+      profile: "primary",
+      status: "healthy",
+      last_seen_at: Time.current
+    )
+  end
+
+  test "requires authentication" do
+    get control_room_path
+    assert_response :redirect
+  end
+
+  test "creates task and question intents" do
+    sign_in_as(@user)
+
+    post control_room_tasks_path, params: {
+      source_id: @source.id,
+      project: "whatsappbot",
+      title: "Ship focused fix",
+      brief: "Make the requested change",
+      acceptance: "Tests and live smoke pass",
+      priority: "high"
+    }
+    assert_redirected_to control_room_path(source_id: @source.id)
+
+    task_intent = @user.orchestration_intents.last
+    assert_equal "create_task", task_intent.kind
+    assert_equal "task", task_intent.payload["kind"]
+
+    post control_room_ask_path, params: {
+      source_id: @source.id,
+      project: "wezbridge",
+      brief: "What should we improve next?"
+    }
+    assert_equal "question", @user.orchestration_intents.last.payload["kind"]
+  end
+
+  test "records operator message before bridge delivery" do
+    task = projected_task
+    sign_in_as(@user)
+
+    post control_room_task_messages_path(task), params: { content: "Please explain the blocker." }
+    assert_redirected_to control_room_path(task_id: task.id)
+
+    intent = @user.orchestration_intents.find_by!(kind: "message")
+    message = task.agent_messages.find_by!(direction: "outgoing")
+    assert_equal "Please explain the blocker.", intent.payload["content"]
+    assert_equal "T-0001", intent.payload["task_id"]
+    assert_equal "operator", message.metadata["provenance"]
+    assert_equal "clawtrol-intent:#{intent.id}", message.metadata["external_id"]
+  end
+
+  test "renders fleet sections and rejects another user's task" do
+    task = projected_task
+    sign_in_as(@user)
+
+    get control_room_path(task_id: task.id)
+    assert_response :success
+    assert_select "h1", "Control Room"
+    assert_includes response.body, "Projected task"
+
+    other = Task.create!(user: users(:two), board: boards(:two), name: "Other",
+      origin_session_key: "wezbridge:primary:task:T-OTHER")
+    post control_room_task_messages_path(other), params: { content: "No access" }
+    assert_response :not_found
+  end
+
+  private
+
+  def projected_task
+    @user.tasks.create!(
+      board: boards(:one),
+      name: "Projected task",
+      description: "Immutable brief",
+      origin_session_id: "T-0001",
+      origin_session_key: "wezbridge:primary:task:T-0001",
+      status: :up_next,
+      blocked: true,
+      state_data: {
+        "orchestration" => {
+          "profile" => "primary",
+          "source_state" => "blocked",
+          "project" => "whatsappbot"
+        }
+      }
+    )
+  end
+end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -106,4 +106,22 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert flash[:new_api_token].present?
     assert flash[:new_api_token].length > 20
   end
+
+  test "creates and revokes a dedicated orchestration token without deleting default token" do
+    sign_in_as(@user)
+    default_token = @user.api_tokens.create!(name: "Keep me")
+
+    post create_orchestration_token_settings_path
+    assert_redirected_to settings_path
+
+    bridge_token = @user.api_tokens.find_by!(name: "Wezbridge control plane")
+    assert bridge_token.grants_scope?("orchestration_bridge:sync")
+    assert @user.api_tokens.exists?(default_token.id)
+    assert flash[:new_orchestration_token].present?
+
+    delete revoke_orchestration_token_settings_path
+    assert_redirected_to settings_path
+    assert bridge_token.reload.revoked_at.present?
+    assert_nil default_token.reload.revoked_at
+  end
 end

--- a/test/helpers/navigation_helper_test.rb
+++ b/test/helpers/navigation_helper_test.rb
@@ -12,6 +12,7 @@ class NavigationHelperTest < ActiveSupport::TestCase
     end
 
     def boards_path = "/boards"
+    def control_room_path = "/control-room"
     def board_path(board)
       board_id = board.respond_to?(:id) ? board.id : board
       "/boards/#{board_id}"

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -38,6 +38,18 @@ class TaskTest < ActiveSupport::TestCase
     assert_equal "none", task.priority
   end
 
+  test "wezbridge projections never auto-assign when mirrored into up next" do
+    task = Task.create!(
+      name: "Projection",
+      board: boards(:one),
+      user: users(:one),
+      status: :up_next,
+      origin_session_key: "wezbridge:primary:task:T-1234"
+    )
+
+    refute task.reload.assigned_to_agent?
+  end
+
   test "model field accepts any string value" do
     # model no longer validates inclusion — any string is allowed
     task = Task.new(name: "Test", board: boards(:one), user: users(:one), model: "any_model_string")

--- a/test/system/control_room_test.rb
+++ b/test/system/control_room_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class ControlRoomTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:one)
+    @source = @user.orchestration_sources.create!(
+      profile: "primary",
+      status: "healthy",
+      last_seen_at: Time.current,
+      panes: [{ "pane_id" => 0, "project" => "wezbridge", "status" => "idle" }]
+    )
+    @task = @user.tasks.create!(
+      board: boards(:one),
+      name: "Review the canary",
+      description: "Confirm the live evidence.",
+      origin_session_id: "T-0001",
+      origin_session_key: "wezbridge:primary:task:T-0001",
+      status: :up_next,
+      blocked: true,
+      state_data: {
+        "orchestration" => {
+          "profile" => "primary",
+          "source_state" => "blocked",
+          "project" => "whatsappbot"
+        }
+      }
+    )
+    sign_in_as(@user)
+  end
+
+  test "creates work and sends a task-scoped message from the cockpit" do
+    visit control_room_path(task_id: @task.id)
+
+    assert_text "Control Room"
+    assert_text "pane 0"
+    within("form[action='#{control_room_tasks_path}']") do
+      fill_in "project", with: "whatsappbot"
+      fill_in "title", with: "Ship a focused fix"
+      fill_in "brief", with: "Implement and verify the requested change."
+      click_button "Create task"
+    end
+
+    assert_text "Task queued as intent"
+    visit control_room_path(task_id: @task.id)
+    within("#task-thread") do
+      fill_in "content", with: "Please show the exact test evidence."
+      click_button "Send"
+    end
+
+    assert_text "Message queued as intent"
+    assert_equal %w[create_task message], @user.orchestration_intents.order(:id).pluck(:kind)
+  end
+end


### PR DESCRIPTION
## Summary
- add scoped outbound Wezbridge sync and disposable task projection
- add Control Room UI for task creation, conversation, and safe FSM intents
- add bounded projection/token safeguards and focused regression coverage

## Verification
- 92 focused Rails tests / 215 assertions
- Control Room system test / 6 assertions
- RuboCop, Brakeman, Bundler Audit, importmap audit
- expand-contract migration and passive Hermes boundary gates
- full local suite: 2562 runs / 5774 assertions; one pre-existing Windows CRLF-only retired ZeroBitch fixture failure; hosted Linux CI is authoritative