### PR TITLE
fix: preserve control-room pane snapshots

### DIFF
--- a/app/services/orchestration/sync_ingestor.rb
+++ b/app/services/orchestration/sync_ingestor.rb
@@ -75,14 +75,15 @@ module Orchestration
     def upsert_source(profile, attributes)
       source = user.orchestration_sources.find_or_initialize_by(profile:)
       health = PayloadSanitizer.call(attributes[:health] || {})
-      source.update!(
+      source_attributes = {
         status: normalize_source_status(health["status"]),
         last_seen_at: Time.current,
         generated_at: parse_time(attributes[:generated_at], allow_blank: true),
         last_error: PayloadSanitizer.text(health["last_error"], maximum: 2_000).presence,
-        health:,
-        panes: PayloadSanitizer.call(attributes[:panes] || [])
-      )
+        health:
+      }
+      source_attributes[:panes] = PayloadSanitizer.call(attributes[:panes]) if attributes.key?(:panes)
+      source.update!(source_attributes)
       source
     end
 

--- a/test/controllers/api/v1/orchestration_controller_test.rb
+++ b/test/controllers/api/v1/orchestration_controller_test.rb
@@ -95,6 +95,20 @@ class Api::V1::OrchestrationControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, response.parsed_body.dig("accepted", "duplicates")
   end
 
+  test "preserves pane snapshot when a delta heartbeat omits panes" do
+    post sync_path, params: base_payload.to_json, headers: @headers
+    assert_response :success
+    source = @user.orchestration_sources.find_by!(profile: "primary")
+    assert_equal [{ "id" => 0, "state" => "idle" }], source.panes
+
+    delta = base_payload.except(:panes)
+    delta[:generated_at] = "2026-07-27T20:00:05Z"
+    post sync_path, params: delta.to_json, headers: @headers
+    assert_response :success
+
+    assert_equal [{ "id" => 0, "state" => "idle" }], source.reload.panes
+  end
+
   test "keeps profiles isolated by authenticated user" do
     post sync_path, params: base_payload.merge(tasks: [task_snapshot]).to_json, headers: @headers
 


### PR DESCRIPTION
## Summary
- preserve the last full pane snapshot when 5-second bridge deltas omit the panes key
- add an integration regression test for full-snapshot followed by delta heartbeat

## Verification
- orchestration controller: 5 runs, 36 assertions, 0 failures
- RuboCop: 2 files, no offenses
- live canary exposed the defect; exact fix will be redeployed after hosted CI