### PR TITLE
docs: record live control-room canary evidence

### DIFF
--- a/.battle-test/20260727-211548/preflight.json
+++ b/.battle-test/20260727-211548/preflight.json
@@ -1,0 +1,10 @@
+{
+  "run_id": "battle-20260727-211548",
+  "project": "clawtrol",
+  "mode": "post-remediation-reverify",
+  "live_url": "private-lan",
+  "authenticated_operator_available": true,
+  "exact_revision": "455f4a57020b0d800fa8e7c54826ff0caf953ca8",
+  "hosted_ci_run": 30316021649,
+  "status": "passed"
+}

--- a/.battle-test/20260727-211548/verification.json
+++ b/.battle-test/20260727-211548/verification.json
@@ -1,0 +1,45 @@
+{
+  "run_id": "battle-20260727-211548",
+  "generated_at": "2026-07-27T21:15:48-03:00",
+  "verdict": "ready_private_lan_canary",
+  "revision": "455f4a57020b0d800fa8e7c54826ff0caf953ca8",
+  "image_digest": "sha256:f10ca2957fac3385e2f466d2fae41977fb20668b55630fdace9f78a859706c12",
+  "checks": {
+    "hosted_ci": "pass",
+    "restored_database_migration": "pass",
+    "health_revision": "pass",
+    "authenticated_live_browser": "pass",
+    "canary_scope": "pass",
+    "idempotent_replay": "pass",
+    "pane_snapshot_persistence": "pass",
+    "runtime_topology": "pass",
+    "legacy_units_inactive": "pass",
+    "live_multi_role_idor": "not_run",
+    "real_watchdog_kill": "blocked",
+    "real_typed_intent": "gated",
+    "canary_observation": "running"
+  },
+  "live": {
+    "source_status": "healthy",
+    "panes": 16,
+    "projected_tasks": 9,
+    "projected_task_runs": 9,
+    "projects": ["whatsappbot-final"],
+    "board_ids": [5],
+    "all_cards": 0,
+    "database_counts": {
+      "users": 5,
+      "boards": 7,
+      "tasks": 442,
+      "task_runs": 204
+    }
+  },
+  "test_evidence": {
+    "clawtrol_main_ci_run": 30316021649,
+    "clawtrol_focused_runs": 5,
+    "clawtrol_focused_assertions": 36,
+    "wezbridge_full_pass": 327,
+    "wezbridge_full_fail": 0,
+    "wezbridge_focused_pass": 32
+  }
+}

--- a/.battle-test/state.json
+++ b/.battle-test/state.json
@@ -1,73 +1,62 @@
 {
   "version": "1.0",
-  "runId": "battle-20260727-011023",
+  "runId": "battle-20260727-211548",
   "project": "clawtrol",
-  "branch": "remediation/safe-lan-revival-20260726",
-  "baseCommit": "9035ed84d1a2f9fd40469ce59815054a61888324",
-  "startedAt": "2026-07-27T01:10:23-03:00",
-  "status": "awaiting_operator",
-  "currentStage": "operator_gates_after_reverify",
+  "branch": "main",
+  "baseCommit": "455f4a57020b0d800fa8e7c54826ff0caf953ca8",
+  "startedAt": "2026-07-27T21:15:48-03:00",
+  "status": "awaiting_canary_observation",
+  "currentStage": "5_report",
   "stages": {
     "0_preflight": {
       "status": "completed",
-      "artifact": ".battle-test/20260727-011023/preflight.json"
+      "artifact": ".battle-test/20260727-211548/preflight.json"
     },
     "1_diagnose": {
       "status": "completed",
       "artifact": "docs/reports/safe-lan-remediation-r1-r4-2026-07-27.md",
-      "verdict": "NOT YET — credential incident and history hard stop remain open"
+      "verdict": "Safe-LAN containment implemented; no critical runtime gate remains red"
     },
     "2_baseline_validation": {
-      "status": "blocked",
-      "reason": "No running immutable candidate with fresh per-role authentication was authorized.",
-      "projectNativeEvidence": "Chromium system suite passed 36/36."
+      "status": "completed_with_limits",
+      "reason": "Project-native hosted system-browser suite plus authenticated live operator flow; separate live multi-role IDOR and visual-diff helpers remain unavailable."
     },
     "3_harden": {
-      "status": "partial",
-      "tracker": "Beads claw-glf (TRACKS.md intentionally not created because project policy requires bd)",
-      "reason": "Repository remediation implemented; runtime incident and rollout gates require operator maintenance windows."
+      "status": "completed",
+      "tracker": "Beads claw-dwp",
+      "reason": "Control Room and bridge implemented; the live pane-delta defect was regression-tested and redeployed."
     },
     "4_reverify": {
-      "status": "blocked",
-      "artifact": ".battle-test/20260727-011023/verification.json",
-      "reason": "Static, unit, integration, system, migration, and dependency gates passed; authenticated multi-role candidate validation and full-history scan did not."
+      "status": "completed_with_limits",
+      "artifact": ".battle-test/20260727-211548/verification.json",
+      "reason": "Exact-SHA CI, restored database, deployment, live browser, scope, idempotency, and topology passed; real watchdog kill/downlink and elapsed soak remain."
     },
     "5_report": {
       "status": "completed",
       "artifact": "artifacts/2026-07-27-battle-test.html",
-      "verdict": "NOT YET"
+      "verdict": "READY AS A PRIVATE-LAN CANARY"
     }
   },
   "gates": [
     {
-      "id": "credential-incident",
-      "status": "awaiting_operator",
-      "reason": "Rotate, cut over, scrub 19 matched rows, prove old-token 401, and preserve fingerprint-only evidence."
+      "id": "canary-observation",
+      "status": "running",
+      "reason": "The observation and usage window must elapse in real time."
     },
     {
-      "id": "history-purge",
-      "status": "awaiting_operator",
-      "reason": "Two complete-history findings require coordinated all-ref rewrite and collaborator re-clone."
-    },
-    {
-      "id": "restored-dump",
-      "status": "awaiting_operator",
-      "reason": "The exact candidate image has not migrated an isolated restored production dump."
-    },
-    {
-      "id": "authenticated-browser",
+      "id": "watchdog-live-kill",
       "status": "blocked",
-      "reason": "Fresh multi-role candidate URL and credentials were not available; routes passed remains zero."
+      "reason": "Focused tests pass; killing the live oversight pane would also drop its monitors. Re-run with an externally graded sacrificial orchestrator-profile pane and the operator present."
     },
     {
-      "id": "deploy",
+      "id": "typed-intent-live",
       "status": "gated",
-      "reason": "Deployment is never automatic."
+      "reason": "Protocol integration tests pass; a real transition is intentionally deferred until a harmless canary task is selected."
     },
     {
-      "id": "mirror-soak",
+      "id": "whatsapp-auto-deploy",
       "status": "gated",
-      "reason": "24-hour dry run, one-session canary, second 24-hour soak, and seven-day column soak remain."
+      "reason": "Runner is implemented, but recipe activation requires repository stability and explicit per-repository operator ratification."
     }
   ]
 }

--- a/artifacts/2026-07-27-battle-test.html
+++ b/artifacts/2026-07-27-battle-test.html
@@ -8,11 +8,11 @@
     :root { color-scheme: dark; font: 15px/1.5 system-ui, sans-serif; background: #090d14; color: #e7edf7; }
     body { max-width: 1120px; margin: 0 auto; padding: 32px 20px 64px; }
     h1, h2 { letter-spacing: -.02em; } h2 { margin-top: 34px; }
-    .banner { border: 1px solid #ef4444; background: #3b1015; border-radius: 12px; padding: 20px; }
-    .banner strong { color: #fca5a5; font-size: 1.35rem; }
+    .banner { border: 1px solid #f59e0b; background: #3a2608; border-radius: 12px; padding: 20px; }
+    .banner strong { color: #fcd34d; font-size: 1.35rem; }
     table { width: 100%; border-collapse: collapse; background: #111827; }
     th, td { border: 1px solid #334155; padding: 9px 11px; text-align: left; vertical-align: top; }
-    th { background: #172033; } .pass { color: #86efac; } .blocked { color: #fca5a5; }
+    th { background: #172033; } .pass { color: #86efac; } .waiting { color: #fcd34d; }
     code { background: #1e293b; padding: 2px 5px; border-radius: 4px; }
     a { color: #93c5fd; } li { margin: 7px 0; }
     .muted { color: #94a3b8; }
@@ -21,60 +21,59 @@
 <body>
   <h1>ClawTrol Battle Test</h1>
   <div class="banner">
-    <strong>🔴 Not yet</strong>
-    <div>Repository containment is substantially implemented and locally green, but the active credential incident,
-      complete-history purge, restored-dump rehearsal, authenticated candidate validation, deployment, and soak gates remain open.</div>
+    <strong>🟡 Ready as a private-LAN canary</strong>
+    <div>The critical containment, immutable deployment, authenticated live browser, and WhatsApp-only
+      Control Room canary are green. Time-based observation and the intentionally deferred real watchdog
+      kill/downlink tests prevent a final green battle-tested verdict tonight.</div>
   </div>
 
   <h2>At-a-glance scorecard</h2>
   <table>
     <tr><th>Signal</th><th>Result</th></tr>
-    <tr><td>Rails unit/integration</td><td class="pass">2,550 runs; 0 failures/errors</td></tr>
-    <tr><td>Chromium system tests</td><td class="pass">36 runs; 0 failures/errors/skips</td></tr>
-    <tr><td>RuboCop / Brakeman</td><td class="pass">868 files, 0 offenses / 0 warnings or parser errors</td></tr>
-    <tr><td>Ruby / importmap dependencies</td><td class="pass">0 known vulnerabilities</td></tr>
-    <tr><td>Migration chain / passive mirror boundary</td><td class="pass">Pass / pass</td></tr>
-    <tr><td>Working-tree / full-history secrets</td><td class="blocked">0 / 2 findings</td></tr>
-    <tr><td>Fresh authenticated roles/routes</td><td class="blocked">0 roles and 0 routes; candidate server not authorized</td></tr>
-    <tr><td>Open critical incident</td><td class="blocked">1 — credential is still active in the old runtime and present in stored data</td></tr>
+    <tr><td>Exact deployed revision</td><td class="pass"><code>455f4a57020b0d800fa8e7c54826ff0caf953ca8</code></td></tr>
+    <tr><td>Hosted CI</td><td class="pass">Main run 30316021649: tests, system browser, lint, security, migration, mirror, boundary, JS scan, image — all pass</td></tr>
+    <tr><td>Live routes</td><td class="pass"><code>/up</code>, <code>/health</code>, login, Control Room, projected task detail/history, sign-out</td></tr>
+    <tr><td>Control Room projection</td><td class="pass">16 panes; 9 unique WhatsApp tasks; 9 unique runs; board 5; zero ALL cards; no other project</td></tr>
+    <tr><td>Runtime topology</td><td class="pass">One Puma, zero workers, one Compose service, three retired systemd units inactive</td></tr>
+    <tr><td>Security criticals / parser errors</td><td class="pass">0 / 0 in hosted gates</td></tr>
+    <tr><td>Live role coverage</td><td class="waiting">One authenticated operator role; hosted system tests cover the application suite, but a separate live multi-role IDOR probe was not run</td></tr>
+    <tr><td>Observation / recovery</td><td class="waiting">Canary clock running; real pane-0 absence recovery and a live downlink transition remain deliberately unexercised</td></tr>
   </table>
 
   <h2>Before → after</h2>
   <table>
-    <tr><th>Dimension</th><th>Before</th><th>Current candidate</th></tr>
-    <tr><td>Same-origin raw marketing/preview HTML</td><td>Executable</td><td class="pass">Moved out of public and served as sandboxed text attachment</td></tr>
-    <tr><td>Legacy executor surfaces</td><td>Routable</td><td class="pass">Fail closed with 410; jobs guarded</td></tr>
-    <tr><td>Direct Hermes control</td><td>Adapters, CLI, tokens, dual mode</td><td class="pass">Removed; scoped passive mirror only</td></tr>
-    <tr><td>Release identity</td><td>Pull/restart could retain an old image</td><td class="pass">Exact-SHA image and <code>/health</code> revision contract</td></tr>
-    <tr><td>Dependency advisories</td><td>Multiple current advisories</td><td class="pass">0 after targeted lockfile updates</td></tr>
-    <tr><td>Exposed credential</td><td>Committed and active</td><td class="blocked">Removed from working tree, but active runtime/data/history still require maintenance</td></tr>
+    <tr><th>Dimension</th><th>Before</th><th>After</th></tr>
+    <tr><td>Same-origin raw HTML</td><td>Executable</td><td class="pass">Inert attachment/source path with sandbox and nosniff</td></tr>
+    <tr><td>Legacy execution</td><td>OpenClaw, Factory, Nightshift, ZeroBitch surfaces existed</td><td class="pass">Retired and fail closed; no worker restored</td></tr>
+    <tr><td>Credential incident</td><td>Exposed active hook credential</td><td class="pass">Revoked/rotated; bridge uses a separate 90-day single-scope token in an owner-only file</td></tr>
+    <tr><td>Release identity</td><td>Source pull/restart could retain an old image</td><td class="pass">Hosted exact-SHA image; health revision equals tested SHA</td></tr>
+    <tr><td>Operator visibility</td><td>Terminal tabs were the monitoring surface</td><td class="pass">Control Room shows 16 panes and nine WhatsApp canary tasks</td></tr>
+    <tr><td>Pane snapshot persistence</td><td>Live delta heartbeat erased the pane list</td><td class="pass">Regression fixed, redeployed, and 16 panes persist across repeated deltas</td></tr>
   </table>
 
   <h2>What was fixed</h2>
   <ul>
-    <li><code>0c4c41d</code> — remediation decisions and R0 recovery anchors.</li>
-    <li><code>1c472ce</code> — fail-closed legacy execution and inert HTML containment.</li>
-    <li><code>c74d0c3</code> — scoped, idempotent passive Hermes mirror and read-only sidecar.</li>
-    <li><code>c7846fc</code> — immutable release, CI/security gates, migration policy, and current documentation map.</li>
+    <li><code>c9b6eda</code> — merged the scoped Control Room API, UI, token model, intent queue, projection contract, and deployment evidence.</li>
+    <li><code>8534c92</code> in Wezbridge — outbound canary bridge, cursor/idempotency contract, typed intents, watchdog, and guarded deploy runner.</li>
+    <li><code>455f4a5</code> — preserved full pane snapshots when five-second delta heartbeats omit the pane array.</li>
+    <li>Live canary — nine task projections and nine runs added to the preserved 433/195 anchor, producing the expected 442/204 totals.</li>
   </ul>
 
   <h2>Operator queue (GATED)</h2>
   <ol>
-    <li>Approve one coordinated containment window: stage protected runtime env, rotate/cut over, scrub the 19 matched rows, and prove the old token returns 401.</li>
-    <li>Approve the exact-ref all-branch/tag history rewrite, obsolete-ref deletion, and mandatory collaborator re-clone.</li>
-    <li>Run the exact candidate image against an isolated copy of the production dump; verify counts and smoke routes.</li>
-    <li>Provide/authorize a running candidate plus fresh administrator/member authentication for multi-role, IDOR, responsive, and visual comparison.</li>
-    <li>Approve immutable production deployment only after the previous gates pass.</li>
-    <li>Complete mirror 24-hour dry run, one metadata-only canary, second 24-hour soak, then seven days before dropping reversible columns.</li>
+    <li>Use the canary normally and keep the observation window running; stop expansion if the cockpit sees no organic use.</li>
+    <li>Run the watchdog proof with an externally graded sacrificial orchestrator-profile pane and the operator present, then exercise one harmless typed intent end to end.</li>
+    <li>Ratify the exact WhatsApp deployment recipe with an explicit yes only after that repository is stable; auto-deploy stays off meanwhile.</li>
+    <li>Public TLS/legal/retention work remains deferred because this is a personal private-LAN deployment.</li>
   </ol>
 
   <h2>Evidence appendix</h2>
   <ul>
-    <li><a href="../docs/reports/safe-lan-remediation-r0-2026-07-26.md">R0 recovery evidence</a></li>
-    <li><a href="../docs/reports/safe-lan-remediation-r1-r4-2026-07-27.md">R1-R4 execution evidence</a></li>
-    <li><a href="../.battle-test/20260727-011023/verification.json">Machine-readable verification</a></li>
-    <li><a href="../remediation-decisions.md">All 36 finding decisions</a></li>
+    <li><a href="../docs/reports/clawtrol-wezbridge-control-room-live-2026-07-27.md">Live control-plane evidence</a></li>
+    <li><a href="../docs/reports/safe-lan-remediation-r1-r4-2026-07-27.md">Safe-LAN remediation evidence</a></li>
+    <li><a href="../.battle-test/20260727-211548/verification.json">Fresh machine-readable verification</a></li>
+    <li><a href="../docs/plans/CLAWTROL-WEZBRIDGE-CONTROL-PLANE.md">Implemented architecture contract</a></li>
   </ul>
-  <p class="muted">No production mutation, remote history rewrite, push, sidecar start, or deployment was performed by this run.</p>
+  <p class="muted">Verdict is intentionally yellow: no critical security or deployment gate is red, but elapsed-time soak cannot be manufactured in a single session.</p>
 </body>
 </html>

--- a/docs/DOCS-MAP.md
+++ b/docs/DOCS-MAP.md
@@ -4,7 +4,7 @@
 <!-- Read this map before any documentation body; never execute a superseded runbook or roadmap. -->
 <!-- CURRENT means authoritative only for the scope stated in its row, not a blanket release verdict. -->
 <!-- The recovered Docker topology is current; systemd and source-pull deployment instructions are superseded. -->
-<!-- Updated: 2026-07-27 with the personal control-room implementation contract. -->
+<!-- Updated: 2026-07-27 with the live personal control-room canary evidence. -->
 
 ## Current sources
 
@@ -16,6 +16,7 @@
 | `docs/reports/safe-lan-remediation-r0-2026-07-26.md` | CURRENT | Latest active-database, container, stopped-service, and health anchors. |
 | `docs/reports/safe-lan-remediation-r1-r4-2026-07-27.md` | CURRENT | Credential cutover, immutable deployment, closed R1-R3 evidence, and remaining passive-mirror gates. |
 | `docs/reports/hermes-delta-review-2026-07-26.md` | CURRENT | Passive-mirror boundary and pinned Hermes compatibility evidence. |
+| `docs/reports/clawtrol-wezbridge-control-room-live-2026-07-27.md` | CURRENT | Live Control Room, outbound Wezbridge canary, exact-SHA deployment, and remaining observation gates. |
 | `docs/plans/CLAWTROL-WEZBRIDGE-CONTROL-PLANE.md` | CURRENT | ClawTrol cockpit, outbound Wezbridge sync, operator intents, supervision, and exact-revision delivery contract. |
 | `Dockerfile` and `docker-compose.yml` | CURRENT | Exact-SHA image and one-web-container deployment topology. |
 | `.claude/skills/deploy-to-vm/SKILL.md` | CURRENT | Immutable release procedure and rollback gate. |

--- a/docs/reports/clawtrol-wezbridge-control-room-live-2026-07-27.md
+++ b/docs/reports/clawtrol-wezbridge-control-room-live-2026-07-27.md
@@ -1,0 +1,73 @@
+# ClawTrol + Wezbridge Control Room — Live Canary Evidence
+<!-- Covers the implemented personal cockpit, outbound bridge, credential boundary, exact-SHA deployment, and live canary proof. -->
+<!-- Key terms: Control Room, disposable projection, single ledger writer, whatsappbot-final canary, typed intents, watchdog. -->
+<!-- Read this after the control-plane plan to see what is live, what was proved, and what remains time-gated. -->
+<!-- ClawTrol never receives pane-control credentials; the PC daemon initiates every connection and keeps ledger authority. -->
+<!-- Production code revision: 455f4a57020b0d800fa8e7c54826ff0caf953ca8. Wezbridge revision: 8534c92df76d3aaa86ad9da0bfbd902aa8c19e32. -->
+<!-- Updated: 2026-07-27. -->
+
+## Outcome
+
+The personal Control Room is live on the private LAN. ClawTrol is the cockpit
+and disposable projection; Wezbridge remains the single local ledger writer
+and the only component with pane authority. The first live scope is
+`whatsappbot-final`: fleet pane metadata is visible, but task, event, and
+message bodies from other projects are filtered before upload.
+
+## Implemented boundary
+
+- Wezbridge pushes health, pane metadata, and allowlisted task metadata to
+  `POST /api/v1/orchestration/sync`; the PC exposes no inbound port.
+- The bridge token has only `orchestration_bridge:sync`, expires after 90 days,
+  and is loaded from an owner-only file. Its value was never printed or stored
+  in repository evidence.
+- ClawTrol queues typed operator intents. The bridge accepts only
+  `create_task`, `message`, `approve`, `retry`, and `cancel`; ledger FSM and
+  repository contracts decide whether a transition is legal.
+- Task projections use `wezbridge:<profile>:task:<ledger-id>`, board 5, and
+  immutable briefs. Runs, events, and replies carry the changing evidence.
+- Unset project configuration fails closed: no task-scoped data uploads.
+  Task-less messages are always dropped.
+- Pane 0 is replaceable; the local daemon owns a 90-second absence watchdog,
+  10-minute cooldown, and three-strike disable.
+- The canary deploy runner is deny-by-default, SHA-pinned, migration-aware, and
+  rollback-capable. It cannot deploy any repository except the explicitly
+  guarded WhatsApp canary.
+
+## Verification
+
+| Gate | Evidence |
+|---|---|
+| ClawTrol hosted CI | Main run `30316021649` passed tests, system browser tests, lint, security, migration, mirror, passive-Hermes boundary, JS scan, and image build. |
+| Focused pane-snapshot regression | 5 controller tests / 36 assertions; RuboCop inspected both touched files with no offenses. |
+| Wezbridge | Main `8534c92`; full suite 327 pass / 0 fail / 1 pre-existing skip. Independent focused bridge/watchdog/deploy run: 32 / 32 pass. |
+| Restored database | Exact image `455f4a5…` migrated and reported no pending migrations against the isolated restored production copy. |
+| Immutable release | Image digest `sha256:f10ca2957fac3385e2f466d2fae41977fb20668b55630fdace9f78a859706c12`; `/up` 200 and `/health` reported `ok` with the exact revision. |
+| Live browser | Real login rendered Control Room, healthy source, 16 panes, nine canary tasks, task detail/history, and sign-out. Temporary login data was restored and removed. |
+| Canary scope | Nine unique projected tasks and nine unique TaskRuns, only `whatsappbot-final`, only board 5, zero `ALL` cards, stable across repeated snapshots. |
+| Pane persistence | 16 panes survived multiple 5-second deltas after the live defect fix; source remained healthy with no last error. |
+| Runtime topology | Compose exposes only `clawdeck`; one Puma process, zero Solid Queue workers; all three retired systemd units remain inactive. |
+| Database counts | 5 users, 7 boards, 442 tasks, 204 TaskRuns. The expected `+9/+9` over the preserved 433/195 anchor is exactly the canary projection. |
+
+The pre-cutover dump remains
+`/home/ggorbalan/.local/share/clawtrol-backups/20260727T232026Z-pre-control-room.dump`
+with SHA-256
+`d0755f23010a352680769a905120a345c74ff3c87de671fc72299fc8452e567c`.
+
+## Remaining gates
+
+- Keep the WhatsApp projection as the canary through the observation window
+  before widening `CLAWTROL_PROJECTS` to the fleet.
+- The real watchdog absence/recovery test and one harmless live downlink intent
+  require separate runtime evidence; focused automated tests already pass. The
+  watchdog test must use an externally graded sacrificial orchestrator-profile
+  pane with the operator present, not terminate the live oversight session.
+- Do not activate the WhatsApp auto-deploy recipe while its repository is
+  incident-active or dirty. Activation still requires the exact recipe values
+  and an explicit operator `yes` for that repository.
+- The passive Hermes mirror remains one-way and metadata-only; no direct Hermes
+  control, OpenClaw, Factory, Nightshift, ZeroBitch, or legacy worker was
+  restored.
+
+The current verdict is **ready as a private-LAN canary**, not a public launch
+and not a completed soak.


### PR DESCRIPTION
## Summary
- record exact-SHA deployment and live Wezbridge canary evidence
- replace the stale battle-test verdict with a fresh, intentionally yellow private-LAN canary report
- document the blocked real watchdog kill and remaining observation/ratification gates

## Verification
- report rendered in a real browser
- JSON state/evidence parsed successfully
- no code or runtime behavior changed