### PR TITLE
docs: record live typed-intent proof

### DIFF
--- a/.battle-test/20260727-211548/verification.json
+++ b/.battle-test/20260727-211548/verification.json
@@ -16,7 +16,7 @@
     "legacy_units_inactive": "pass",
     "live_multi_role_idor": "not_run",
     "real_watchdog_kill": "blocked",
-    "real_typed_intent": "gated",
+    "real_typed_intent": "pass",
     "canary_observation": "running"
   },
   "live": {

--- a/.battle-test/state.json
+++ b/.battle-test/state.json
@@ -50,8 +50,8 @@
     },
     {
       "id": "typed-intent-live",
-      "status": "gated",
-      "reason": "Protocol integration tests pass; a real transition is intentionally deferred until a harmless canary task is selected."
+      "status": "completed",
+      "reason": "A live cancel for nonexistent task T-999999 crossed the bridge, was rejected by the kernel, persisted, and returned with zero pending intents and no real task mutation."
     },
     {
       "id": "whatsapp-auto-deploy",

--- a/artifacts/2026-07-27-battle-test.html
+++ b/artifacts/2026-07-27-battle-test.html
@@ -24,7 +24,7 @@
     <strong>🟡 Ready as a private-LAN canary</strong>
     <div>The critical containment, immutable deployment, authenticated live browser, and WhatsApp-only
       Control Room canary are green. Time-based observation and the intentionally deferred real watchdog
-      kill/downlink tests prevent a final green battle-tested verdict tonight.</div>
+      kill test prevents a final green battle-tested verdict tonight.</div>
   </div>
 
   <h2>At-a-glance scorecard</h2>
@@ -37,7 +37,8 @@
     <tr><td>Runtime topology</td><td class="pass">One Puma, zero workers, one Compose service, three retired systemd units inactive</td></tr>
     <tr><td>Security criticals / parser errors</td><td class="pass">0 / 0 in hosted gates</td></tr>
     <tr><td>Live role coverage</td><td class="waiting">One authenticated operator role; hosted system tests cover the application suite, but a separate live multi-role IDOR probe was not run</td></tr>
-    <tr><td>Observation / recovery</td><td class="waiting">Canary clock running; real pane-0 absence recovery and a live downlink transition remain deliberately unexercised</td></tr>
+    <tr><td>Typed-intent downlink</td><td class="pass">A harmless nonexistent-task cancel crossed the live bridge and was audited as one kernel rejection with zero pending intents</td></tr>
+    <tr><td>Observation / recovery</td><td class="waiting">Canary clock running; real pane-0 absence recovery remains deliberately unexercised</td></tr>
   </table>
 
   <h2>Before → after</h2>
@@ -62,7 +63,7 @@
   <h2>Operator queue (GATED)</h2>
   <ol>
     <li>Use the canary normally and keep the observation window running; stop expansion if the cockpit sees no organic use.</li>
-    <li>Run the watchdog proof with an externally graded sacrificial orchestrator-profile pane and the operator present, then exercise one harmless typed intent end to end.</li>
+    <li>Run the watchdog proof with an externally graded sacrificial orchestrator-profile pane and the operator present.</li>
     <li>Ratify the exact WhatsApp deployment recipe with an explicit yes only after that repository is stable; auto-deploy stays off meanwhile.</li>
     <li>Public TLS/legal/retention work remains deferred because this is a personal private-LAN deployment.</li>
   </ol>

--- a/docs/reports/clawtrol-wezbridge-control-room-live-2026-07-27.md
+++ b/docs/reports/clawtrol-wezbridge-control-room-live-2026-07-27.md
@@ -46,6 +46,7 @@ message bodies from other projects are filtered before upload.
 | Live browser | Real login rendered Control Room, healthy source, 16 panes, nine canary tasks, task detail/history, and sign-out. Temporary login data was restored and removed. |
 | Canary scope | Nine unique projected tasks and nine unique TaskRuns, only `whatsappbot-final`, only board 5, zero `ALL` cards, stable across repeated snapshots. |
 | Pane persistence | 16 panes survived multiple 5-second deltas after the live defect fix; source remained healthy with no last error. |
+| Typed-intent downlink | A live `cancel` for deliberately nonexistent ledger task `T-999999` crossed ClawTrol → PC, was rejected by the kernel, persisted, returned, and left zero pending intents without changing real work. |
 | Runtime topology | Compose exposes only `clawdeck`; one Puma process, zero Solid Queue workers; all three retired systemd units remain inactive. |
 | Database counts | 5 users, 7 boards, 442 tasks, 204 TaskRuns. The expected `+9/+9` over the preserved 433/195 anchor is exactly the canary projection. |
 
@@ -58,10 +59,10 @@ with SHA-256
 
 - Keep the WhatsApp projection as the canary through the observation window
   before widening `CLAWTROL_PROJECTS` to the fleet.
-- The real watchdog absence/recovery test and one harmless live downlink intent
-  require separate runtime evidence; focused automated tests already pass. The
-  watchdog test must use an externally graded sacrificial orchestrator-profile
-  pane with the operator present, not terminate the live oversight session.
+- The real watchdog absence/recovery test requires separate runtime evidence;
+  focused automated tests and the live typed-intent downlink pass. The watchdog
+  test must use an externally graded sacrificial orchestrator-profile pane with
+  the operator present, not terminate the live oversight session.
 - Do not activate the WhatsApp auto-deploy recipe while its repository is
   incident-active or dirty. Activation still requires the exact recipe values
   and an explicit operator `yes` for that repository.


### PR DESCRIPTION
## Summary
- record the safe live ClawTrol-to-Wezbridge downlink proof
- mark the nonexistent-task cancel as one audited kernel rejection with zero pending intents
- leave only the real watchdog exercise and elapsed canary observation open

## Verification
- live intent reached processed/rejected state once and stayed stable across later polls
- source remained healthy with 16 panes
- JSON evidence parsed; diff check passed
- docs-only follow-up to green PR #41