### PR TITLE
feat: make Control Room full-width and fleet-driven

### DIFF
--- a/app/controllers/control_room_controller.rb
+++ b/app/controllers/control_room_controller.rb
@@ -6,6 +6,7 @@ class ControlRoomController < ApplicationController
   def show
     @sources = current_user.orchestration_sources.most_recent
     @source = selected_source(@sources)
+    @project_options = project_options(@source)
     @tasks = projected_tasks.includes(:agent_messages).order(updated_at: :desc).limit(250)
     @pending_intents = current_user.orchestration_intents.pending.limit(100)
     categorize_tasks
@@ -57,6 +58,17 @@ class ControlRoomController < ApplicationController
     return sources.find_by(id: params[:source_id]) if params[:source_id].present?
 
     sources.first
+  end
+
+  def project_options(source)
+    Array(source&.panes).filter_map do |pane|
+      project = pane["project"].to_s.strip
+      next if project.blank?
+
+      pane_id = pane["pane_id"] || pane["id"]
+      status = pane["status"] || pane["state"] || "unknown"
+      ["pane #{pane_id} — #{project} (#{status})", project]
+    end.uniq { |option| option.last }
   end
 
   def categorize_tasks

--- a/app/views/control_room/show.html.erb
+++ b/app/views/control_room/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, "Control Room" %>
 <% content_for :breadcrumb_standalone, "Control Room" %>
+<% content_for :main_width_class, "w-full max-w-none mx-auto" %>
 
 <div class="py-8 space-y-6">
   <header class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -68,9 +69,12 @@
       <p class="mt-1 text-xs text-content-muted">Safe work starts automatically after the local contract accepts it.</p>
       <%= form_with url: control_room_tasks_path, class: "mt-4 grid gap-3" do |form| %>
         <%= form.hidden_field :source_id, value: @source&.id %>
-        <%= form.label :project, "Project", class: "sr-only" %>
-        <%= form.text_field :project, required: true, placeholder: "Project, e.g. whatsappbot",
-              class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+        <div>
+          <%= form.label :project, "Target pane / project", class: "mb-1 block text-xs font-medium text-content-secondary" %>
+          <%= form.select :project, @project_options, { prompt: "Choose a live pane / project" },
+                required: true,
+                class: "w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+        </div>
         <%= form.label :title, "Task title", class: "sr-only" %>
         <%= form.text_field :title, placeholder: "Task title",
               class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
@@ -95,9 +99,12 @@
       <p class="mt-1 text-xs text-content-muted">Pane 0 answers in the task thread; the terminal remains optional.</p>
       <%= form_with url: control_room_ask_path, class: "mt-4 grid gap-3" do |form| %>
         <%= form.hidden_field :source_id, value: @source&.id %>
-        <%= form.label :project, "Question project", class: "sr-only" %>
-        <%= form.text_field :project, required: true, placeholder: "Project or topic",
-              class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+        <div>
+          <%= form.label :project, "Context pane / project", class: "mb-1 block text-xs font-medium text-content-secondary" %>
+          <%= form.select :project, @project_options, { prompt: "Choose a live pane / project" },
+                required: true,
+                class: "w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+        </div>
         <%= form.label :title, "Question title", class: "sr-only" %>
         <%= form.text_field :title, placeholder: "Question title",
               class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,7 +67,7 @@
       <div class="h-screen flex flex-col bg-bg-base">
         <%= render "application/navbar" %>
         <div class="flex-1 overflow-y-auto px-4 pb-16 md:pb-0 scroll-safe-bottom overscroll-contain [-webkit-overflow-scrolling:touch]">
-          <main id="main-content" class="container max-w-7xl mx-auto text-content-secondary font-normal text-sm">
+          <main id="main-content" class="<%= content_for(:main_width_class).presence || "container max-w-7xl mx-auto" %> text-content-secondary font-normal text-sm">
             <%= yield %>
           </main>
         </div>

--- a/test/controllers/control_room_controller_test.rb
+++ b/test/controllers/control_room_controller_test.rb
@@ -59,11 +59,18 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
 
   test "renders fleet sections and rejects another user's task" do
     task = projected_task
+    @source.update!(panes: [
+      { "pane_id" => 0, "project" => "wezbridge", "status" => "idle" },
+      { "pane_id" => 5, "project" => "whatsappbot", "status" => "working" }
+    ])
     sign_in_as(@user)
 
     get control_room_path(task_id: task.id)
     assert_response :success
     assert_select "h1", "Control Room"
+    assert_select "main#main-content.w-full.max-w-none"
+    assert_select "select[name='project']", count: 2
+    assert_select "option[value='whatsappbot']", text: /pane 5/, count: 2
     assert_includes response.body, "Projected task"
 
     other = Task.create!(user: users(:two), board: boards(:two), name: "Other",

--- a/test/system/control_room_test.rb
+++ b/test/system/control_room_test.rb
@@ -36,7 +36,7 @@ class ControlRoomTest < ApplicationSystemTestCase
     assert_text "Control Room"
     assert_text "pane 0"
     within("form[action='#{control_room_tasks_path}']") do
-      fill_in "project", with: "whatsappbot"
+      select "pane 0 — wezbridge (idle)", from: "Target pane / project"
       fill_in "title", with: "Ship a focused fix"
       fill_in "brief", with: "Implement and verify the requested change."
       click_button "Create task"


### PR DESCRIPTION
## What changed
- use the full desktop width on Control Room only
- replace manual project entry with live pane/project selectors
- keep dispatch authority in the Wezbridge FSM

## Verification
- focused Rails controller: 4 runs, 20 assertions, 0 failures
- RuboCop: 3 files, no offenses
- production asset build passed
- full local image run: 2563 tests, 7 unrelated legacy/git-environment failures; hosted CI is the release gate