### PR TITLE
fix: make Control Room live and unambiguous

### DIFF
--- a/app/controllers/control_room_controller.rb
+++ b/app/controllers/control_room_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class ControlRoomController < ApplicationController
-  before_action :set_task, only: %i[message approve retry cancel]
+  before_action :set_task, only: %i[thread message approve retry cancel]
+  helper_method :pane_display_status
 
   def show
+    @full_width_page = true
     @sources = current_user.orchestration_sources.most_recent
     @source = selected_source(@sources)
     @project_options = project_options(@source)
@@ -15,6 +17,10 @@ class ControlRoomController < ApplicationController
 
   def create_task
     create_task_intent(kind: "task")
+  end
+
+  def thread
+    render partial: "thread_messages", locals: { task: @task }
   end
 
   def ask
@@ -66,9 +72,14 @@ class ControlRoomController < ApplicationController
       next if project.blank?
 
       pane_id = pane["pane_id"] || pane["id"]
-      status = pane["status"] || pane["state"] || "unknown"
+      status = pane_display_status(pane)
       ["pane #{pane_id} — #{project} (#{status})", project]
     end.uniq { |option| option.last }
+  end
+
+  def pane_display_status(pane)
+    status = (pane["status"] || pane["state"]).to_s
+    status.blank? || status == "unknown" ? "present" : status
   end
 
   def categorize_tasks

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,9 +5,14 @@ import "controllers"
 // ActionCable channels for WebSocket communication
 import "channels"
 
-// Chartkick for analytics charts (dynamic import — CDN failure must not block core JS)
-import("chartkick").catch(() => console.warn("chartkick failed to load — charts disabled"))
-import("Chart.js").catch(() => console.warn("Chart.js failed to load — charts disabled"))
+// Charting is analytics-only; CDN failure must not affect or warn on the core UI.
+const loadAnalyticsCharts = () => {
+  if (!document.querySelector('meta[name="charting-enabled"]')) return
+
+  import("chartkick").catch(() => console.warn("chartkick failed to load — charts disabled"))
+  import("Chart.js").catch(() => console.warn("Chart.js failed to load — charts disabled"))
+}
+document.addEventListener("turbo:load", loadAnalyticsCharts)
 
 // Instant modal skeleton — show loading state immediately on task card click
 // so the modal appears before Turbo finishes fetching the panel content.

--- a/app/javascript/controllers/control_room_thread_controller.js
+++ b/app/javascript/controllers/control_room_thread_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["messages", "status"]
+  static values = { url: String, interval: { type: Number, default: 5000 } }
+
+  connect() {
+    this.refresh = this.refresh.bind(this)
+    this.handleVisibility = this.handleVisibility.bind(this)
+    this.timer = window.setInterval(this.refresh, this.intervalValue)
+    document.addEventListener("visibilitychange", this.handleVisibility)
+  }
+
+  disconnect() {
+    window.clearInterval(this.timer)
+    document.removeEventListener("visibilitychange", this.handleVisibility)
+  }
+
+  handleVisibility() {
+    if (document.visibilityState === "visible") this.refresh()
+  }
+
+  async refresh() {
+    if (this.loading || document.visibilityState === "hidden") return
+
+    this.loading = true
+    try {
+      const response = await fetch(this.urlValue, {
+        headers: { Accept: "text/html" },
+        credentials: "same-origin",
+        cache: "no-store"
+      })
+      if (!response.ok) throw new Error(`thread HTTP ${response.status}`)
+      this.updateMessages(await response.text())
+      this.showStatus("Live updates on", "text-green-400")
+    } catch (_error) {
+      this.showStatus("Live update delayed", "text-yellow-400")
+    } finally {
+      this.loading = false
+    }
+  }
+
+  updateMessages(html) {
+    const documentFragment = new DOMParser().parseFromString(html, "text/html")
+    const next = documentFragment.querySelector("#task-thread-messages")
+    if (!next || next.dataset.version === this.messagesTarget.dataset.version) return
+
+    this.messagesTarget.innerHTML = next.innerHTML
+    this.messagesTarget.dataset.version = next.dataset.version
+  }
+
+  showStatus(text, colorClass) {
+    this.statusTarget.textContent = text
+    this.statusTarget.classList.remove("text-green-400", "text-yellow-400")
+    this.statusTarget.classList.add(colorClass)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -52,6 +52,7 @@ import ZerobitchFleetController from "controllers/zerobitch_fleet_controller"
 import ZerobitchSpawnController from "controllers/zerobitch_spawn_controller"
 import ZerobitchAgentController from "controllers/zerobitch_agent_controller"
 import ActiveFlowsController from "controllers/active_flows_controller"
+import ControlRoomThreadController from "controllers/control_room_thread_controller"
 
 application.register("notifications", NotificationsController)
 application.register("auto-claim-tags", AutoClaimTagsController)
@@ -100,6 +101,7 @@ application.register("zerobitch-fleet", ZerobitchFleetController)
 application.register("zerobitch-spawn", ZerobitchSpawnController)
 application.register("zerobitch-agent", ZerobitchAgentController)
 application.register("active-flows", ActiveFlowsController)
+application.register("control-room-thread", ControlRoomThreadController)
 
 import ThemeToggleController from "controllers/theme_toggle_controller"
 application.register("theme-toggle", ThemeToggleController)

--- a/app/views/analytics/show.html.erb
+++ b/app/views/analytics/show.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <meta name="charting-enabled" content="true">
+<% end %>
+
 <% content_for :breadcrumb_standalone do %>
   Analytics
 <% end %>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -62,7 +62,7 @@
 
       <%# Gateway health indicator %>
       <% if authenticated? %>
-        <%= render "shared/gateway_health" %>
+        <%= render "shared/gateway_health" unless controller_name == "control_room" %>
       <% end %>
       <%# Mobile hamburger menu %>
       <% if authenticated? %>

--- a/app/views/control_room/_thread_messages.html.erb
+++ b/app/views/control_room/_thread_messages.html.erb
@@ -1,0 +1,20 @@
+<% messages = task.agent_messages.sort_by(&:created_at) %>
+<% version = [messages.length, messages.last&.id, messages.last&.created_at&.to_i].compact.join("-") %>
+<div id="task-thread-messages"
+     class="mt-5 space-y-3"
+     data-control-room-thread-target="messages"
+     data-version="<%= version %>">
+  <% messages.each do |message| %>
+    <% operator = message.metadata["provenance"] == "operator" %>
+    <article class="rounded-lg border border-border p-3 <%= operator ? "ml-8 bg-accent/5" : "mr-8 bg-bg-elevated" %>">
+      <div class="flex items-center justify-between gap-3 text-xs">
+        <span class="font-semibold text-content"><%= operator ? "You" : message.display_sender %></span>
+        <span class="text-content-muted"><%= message.created_at.strftime("%Y-%m-%d %H:%M") %></span>
+      </div>
+      <p class="mt-2 whitespace-pre-wrap text-sm text-content-secondary"><%= message.content %></p>
+    </article>
+  <% end %>
+  <% if messages.empty? %>
+    <p class="text-sm text-content-muted">No messages yet.</p>
+  <% end %>
+</div>

--- a/app/views/control_room/show.html.erb
+++ b/app/views/control_room/show.html.erb
@@ -1,7 +1,5 @@
 <% content_for :title, "Control Room" %>
 <% content_for :breadcrumb_standalone, "Control Room" %>
-<% content_for :main_width_class, "w-full max-w-none mx-auto" %>
-
 <div class="py-8 space-y-6">
   <header class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
     <div>
@@ -46,8 +44,9 @@
         </p>
       </div>
       <% if @source&.health&.dig("fleet") %>
+        <% a2a_updates = @source.health.dig("fleet", "a2a_envelopes").to_i %>
         <span class="text-xs text-content-muted">
-          <%= @source.health.dig("fleet", "a2a_envelopes").to_i %> recent A2A events
+          <%= a2a_updates.positive? ? "#{a2a_updates} A2A updates in latest sync" : "No A2A updates in latest sync" %>
         </span>
       <% end %>
     </div>
@@ -56,7 +55,7 @@
         <% @source.panes.each do |pane| %>
           <span class="rounded-lg border border-border bg-bg-elevated px-3 py-2 text-xs text-content-secondary">
             pane <%= pane["pane_id"] || pane["id"] %>
-            <span class="ml-1 text-content-muted"><%= pane["project"] %> · <%= pane["status"] %></span>
+            <span class="ml-1 text-content-muted"><%= pane["project"] %> · <%= pane_display_status(pane) %></span>
           </span>
         <% end %>
       </div>
@@ -66,27 +65,31 @@
   <section class="grid gap-4 lg:grid-cols-2">
     <div class="rounded-xl border border-border bg-bg-surface p-5">
       <h2 class="text-lg font-semibold text-content">New Task</h2>
-      <p class="mt-1 text-xs text-content-muted">Safe work starts automatically after the local contract accepts it.</p>
+      <p class="mt-1 text-xs text-content-muted">
+        Choose a pane's project context. Wezbridge validates the task and decides who runs it.
+      </p>
       <%= form_with url: control_room_tasks_path, class: "mt-4 grid gap-3" do |form| %>
-        <%= form.hidden_field :source_id, value: @source&.id %>
+        <%= form.hidden_field :source_id, value: @source&.id, id: "task_source_id" %>
         <div>
-          <%= form.label :project, "Target pane / project", class: "mb-1 block text-xs font-medium text-content-secondary" %>
+          <%= form.label :project, "Work context", for: "task_project", class: "mb-1 block text-xs font-medium text-content-secondary" %>
           <%= form.select :project, @project_options, { prompt: "Choose a live pane / project" },
+                id: "task_project",
                 required: true,
                 class: "w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
         </div>
-        <%= form.label :title, "Task title", class: "sr-only" %>
-        <%= form.text_field :title, placeholder: "Task title",
+        <%= form.label :title, "Task title", for: "task_title", class: "sr-only" %>
+        <%= form.text_field :title, id: "task_title", placeholder: "Task title",
               class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-        <%= form.label :brief, "Task brief", class: "sr-only" %>
-        <%= form.text_area :brief, required: true, rows: 4, placeholder: "What should be done?",
+        <%= form.label :brief, "Task brief", for: "task_brief", class: "sr-only" %>
+        <%= form.text_area :brief, id: "task_brief", required: true, rows: 4, placeholder: "What should be done?",
               class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-        <%= form.label :acceptance, "Acceptance criteria", class: "sr-only" %>
-        <%= form.text_area :acceptance, rows: 2, placeholder: "What does done look like?",
+        <%= form.label :acceptance, "Acceptance criteria", for: "task_acceptance", class: "sr-only" %>
+        <%= form.text_area :acceptance, id: "task_acceptance", rows: 2, placeholder: "What does done look like?",
               class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
         <div class="flex items-center justify-between gap-3">
-          <%= form.label :priority, "Priority", class: "sr-only" %>
+          <%= form.label :priority, "Priority", for: "task_priority", class: "sr-only" %>
           <%= form.select :priority, [["Normal", "normal"], ["High", "high"], ["Low", "low"]], {},
+                id: "task_priority",
                 class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
           <%= form.submit "Create task", disabled: @source.blank?,
                 class: "cursor-pointer rounded-lg bg-accent px-4 py-2 font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40" %>
@@ -96,20 +99,23 @@
 
     <div class="rounded-xl border border-border bg-bg-surface p-5">
       <h2 class="text-lg font-semibold text-content">Ask Orchestrator</h2>
-      <p class="mt-1 text-xs text-content-muted">Pane 0 answers in the task thread; the terminal remains optional.</p>
+      <p class="mt-1 text-xs text-content-muted">
+        Ask pane 0 about the selected pane's project. The answer appears in the task thread.
+      </p>
       <%= form_with url: control_room_ask_path, class: "mt-4 grid gap-3" do |form| %>
-        <%= form.hidden_field :source_id, value: @source&.id %>
+        <%= form.hidden_field :source_id, value: @source&.id, id: "question_source_id" %>
         <div>
-          <%= form.label :project, "Context pane / project", class: "mb-1 block text-xs font-medium text-content-secondary" %>
+          <%= form.label :project, "Question context", for: "question_project", class: "mb-1 block text-xs font-medium text-content-secondary" %>
           <%= form.select :project, @project_options, { prompt: "Choose a live pane / project" },
+                id: "question_project",
                 required: true,
                 class: "w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
         </div>
-        <%= form.label :title, "Question title", class: "sr-only" %>
-        <%= form.text_field :title, placeholder: "Question title",
+        <%= form.label :title, "Question title", for: "question_title", class: "sr-only" %>
+        <%= form.text_field :title, id: "question_title", placeholder: "Question title",
               class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-        <%= form.label :brief, "Question", class: "sr-only" %>
-        <%= form.text_area :brief, required: true, rows: 5, placeholder: "What do you want to discuss?",
+        <%= form.label :brief, "Question", for: "question_brief", class: "sr-only" %>
+        <%= form.text_area :brief, id: "question_brief", required: true, rows: 5, placeholder: "What do you want to discuss?",
               class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
         <div class="flex justify-end">
           <%= form.submit "Ask", disabled: @source.blank?,
@@ -141,12 +147,19 @@
 
   <% if @selected_task %>
     <% state = @selected_task.state_data.fetch("orchestration", {}) %>
-    <section id="task-thread" class="rounded-xl border border-border bg-bg-surface p-5">
+    <section id="task-thread"
+             class="rounded-xl border border-border bg-bg-surface p-5"
+             data-controller="control-room-thread"
+             data-control-room-thread-url-value="<%= control_room_task_thread_path(@selected_task) %>"
+             data-control-room-thread-interval-value="5000">
       <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
           <p class="text-xs uppercase tracking-wider text-content-muted"><%= state["project"] %> · <%= state["source_state"] %></p>
           <h2 class="mt-1 text-xl font-semibold text-content"><%= @selected_task.name %></h2>
           <p class="mt-2 whitespace-pre-wrap text-sm text-content-secondary"><%= @selected_task.description %></p>
+          <p class="mt-2 text-xs text-green-400"
+             data-control-room-thread-target="status"
+             aria-live="polite">Live updates on</p>
         </div>
         <div class="flex flex-wrap gap-2">
           <% if @selected_task.blocked? || state["source_state"] == "review" %>
@@ -161,21 +174,7 @@
         </div>
       </div>
 
-      <div class="mt-5 space-y-3">
-        <% @selected_task.agent_messages.sort_by(&:created_at).each do |message| %>
-          <% operator = message.metadata["provenance"] == "operator" %>
-          <article class="rounded-lg border border-border p-3 <%= operator ? "ml-8 bg-accent/5" : "mr-8 bg-bg-elevated" %>">
-            <div class="flex items-center justify-between gap-3 text-xs">
-              <span class="font-semibold text-content"><%= operator ? "You" : message.display_sender %></span>
-              <span class="text-content-muted"><%= message.created_at.strftime("%Y-%m-%d %H:%M") %></span>
-            </div>
-            <p class="mt-2 whitespace-pre-wrap text-sm text-content-secondary"><%= message.content %></p>
-          </article>
-        <% end %>
-        <% if @selected_task.agent_messages.empty? %>
-          <p class="text-sm text-content-muted">No messages yet.</p>
-        <% end %>
-      </div>
+      <%= render "thread_messages", task: @selected_task %>
 
       <%= form_with url: control_room_task_messages_path(@selected_task), class: "mt-5 flex gap-3" do |form| %>
         <%= form.label :content, "Reply", class: "sr-only" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,7 +67,8 @@
       <div class="h-screen flex flex-col bg-bg-base">
         <%= render "application/navbar" %>
         <div class="flex-1 overflow-y-auto px-4 pb-16 md:pb-0 scroll-safe-bottom overscroll-contain [-webkit-overflow-scrolling:touch]">
-          <main id="main-content" class="<%= content_for(:main_width_class).presence || "container max-w-7xl mx-auto" %> text-content-secondary font-normal text-sm">
+          <% main_width = @full_width_page ? "w-full max-w-none mx-auto" : (content_for(:main_width_class).presence || "container max-w-7xl mx-auto") %>
+          <main id="main-content" class="<%= main_width %> text-content-secondary font-normal text-sm">
             <%= yield %>
           </main>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,6 +258,7 @@ Rails.application.routes.draw do
   end
 
   get "control-room", to: "control_room#show", as: :control_room
+  get "control-room/tasks/:task_id/thread", to: "control_room#thread", as: :control_room_task_thread
   post "control-room/tasks", to: "control_room#create_task", as: :control_room_tasks
   post "control-room/ask", to: "control_room#ask", as: :control_room_ask
   post "control-room/tasks/:task_id/messages", to: "control_room#message", as: :control_room_task_messages

--- a/test/controllers/analytics_controller_test.rb
+++ b/test/controllers/analytics_controller_test.rb
@@ -45,6 +45,7 @@ class AnalyticsControllerTest < ActionDispatch::IntegrationTest
 
       get analytics_path(period: "7d")
       assert_response :success
+      assert_select "meta[name='charting-enabled'][content='true']", count: 1
       assert_includes response.body, "COST ANALYTICS"
       assert_includes response.body, "glm-4.7"
     ensure

--- a/test/controllers/control_room_controller_test.rb
+++ b/test/controllers/control_room_controller_test.rb
@@ -59,23 +59,54 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
 
   test "renders fleet sections and rejects another user's task" do
     task = projected_task
-    @source.update!(panes: [
-      { "pane_id" => 0, "project" => "wezbridge", "status" => "idle" },
-      { "pane_id" => 5, "project" => "whatsappbot", "status" => "working" }
-    ])
+    @source.update!(
+      health: { "fleet" => { "a2a_envelopes" => 0 } },
+      panes: [
+        { "pane_id" => 0, "project" => "wezbridge", "status" => "idle" },
+        { "pane_id" => 5, "project" => "whatsappbot", "status" => "working" },
+        { "pane_id" => 9, "project" => "omniremote", "status" => "unknown" }
+      ]
+    )
     sign_in_as(@user)
 
     get control_room_path(task_id: task.id)
     assert_response :success
     assert_select "h1", "Control Room"
     assert_select "main#main-content.w-full.max-w-none"
-    assert_select "select[name='project']", count: 2
+    assert_select "[data-controller='gateway-health']", count: 0
+    assert_select "select#task_project", count: 1
+    assert_select "select#question_project", count: 1
     assert_select "option[value='whatsappbot']", text: /pane 5/, count: 2
+    assert_select "option[value='omniremote']", text: /present/, count: 2
+    assert_includes response.body, "No A2A updates in latest sync"
     assert_includes response.body, "Projected task"
+    ids = css_select("[id]").map { |element| element["id"] }
+    assert_equal ids.uniq, ids, "Control Room must not render duplicate HTML ids"
 
     other = Task.create!(user: users(:two), board: boards(:two), name: "Other",
       origin_session_key: "wezbridge:primary:task:T-OTHER")
     post control_room_task_messages_path(other), params: { content: "No access" }
+    assert_response :not_found
+  end
+
+  test "renders an owned task thread fragment and hides another user's task" do
+    task = projected_task
+    task.agent_messages.create!(
+      direction: "incoming",
+      message_type: "output",
+      content: "Fresh orchestrator reply",
+      sender_name: "pane 0"
+    )
+    sign_in_as(@user)
+
+    get control_room_task_thread_path(task)
+    assert_response :success
+    assert_select "#task-thread-messages[data-version]"
+    assert_includes response.body, "Fresh orchestrator reply"
+
+    other = Task.create!(user: users(:two), board: boards(:two), name: "Other",
+      origin_session_key: "wezbridge:primary:task:T-OTHER")
+    get control_room_task_thread_path(other)
     assert_response :not_found
   end
 

--- a/test/system/control_room_test.rb
+++ b/test/system/control_room_test.rb
@@ -36,7 +36,7 @@ class ControlRoomTest < ApplicationSystemTestCase
     assert_text "Control Room"
     assert_text "pane 0"
     within("form[action='#{control_room_tasks_path}']") do
-      select "pane 0 — wezbridge (idle)", from: "Target pane / project"
+      select "pane 0 — wezbridge (idle)", from: "Work context"
       fill_in "title", with: "Ship a focused fix"
       fill_in "brief", with: "Implement and verify the requested change."
       click_button "Create task"
@@ -51,5 +51,21 @@ class ControlRoomTest < ApplicationSystemTestCase
 
     assert_text "Message queued as intent"
     assert_equal %w[create_task message], @user.orchestration_intents.order(:id).pluck(:kind)
+  end
+
+  test "shows a new orchestrator reply without reloading the page" do
+    visit control_room_path(task_id: @task.id, anchor: "task-thread")
+    assert_text "Live updates on"
+
+    @task.agent_messages.create!(
+      direction: "incoming",
+      message_type: "output",
+      content: "Reply appeared through live refresh.",
+      sender_name: "pane 0"
+    )
+
+    within("#task-thread-messages") do
+      assert_text "Reply appeared through live refresh.", wait: 8
+    end
   end
 end


### PR DESCRIPTION
## Summary
- use the full viewport and remove the retired gateway Offline badge from Control Room
- make pane choices explicit project contexts and normalize present panes with unknown activity
- live-refresh task replies every five seconds without disturbing the reply form
- remove duplicate form IDs and clarify latest-sync A2A wording
- load analytics chart dependencies only on Analytics

## Verification
- focused controller tests: 7 runs, 38 assertions, 0 failures
- RuboCop: 4 files, 0 offenses
- full local Rails suite: 2,564 runs; 7 known Docker/git-context failures in retired Factory/ZeroBitch surfaces, no new Control Room failures
- hosted CI and system test required before merge