### PR TITLE
fix: render Control Room message times relatively

### DIFF
--- a/app/views/control_room/_thread_messages.html.erb
+++ b/app/views/control_room/_thread_messages.html.erb
@@ -9,7 +9,9 @@
     <article class="rounded-lg border border-border p-3 <%= operator ? "ml-8 bg-accent/5" : "mr-8 bg-bg-elevated" %>">
       <div class="flex items-center justify-between gap-3 text-xs">
         <span class="font-semibold text-content"><%= operator ? "You" : message.display_sender %></span>
-        <span class="text-content-muted"><%= message.created_at.strftime("%Y-%m-%d %H:%M") %></span>
+        <time class="text-content-muted"
+              datetime="<%= message.created_at.iso8601 %>"
+              title="<%= message.created_at.iso8601 %>"><%= time_ago_in_words(message.created_at) %> ago</time>
       </div>
       <p class="mt-2 whitespace-pre-wrap text-sm text-content-secondary"><%= message.content %></p>
     </article>

--- a/test/controllers/control_room_controller_test.rb
+++ b/test/controllers/control_room_controller_test.rb
@@ -102,6 +102,7 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     get control_room_task_thread_path(task)
     assert_response :success
     assert_select "#task-thread-messages[data-version]"
+    assert_select "time[datetime][title]", text: /ago/
     assert_includes response.body, "Fresh orchestrator reply"
 
     other = Task.create!(user: users(:two), board: boards(:two), name: "Other",


### PR DESCRIPTION
## Summary
- show conversation timestamps as relative time so server UTC is not mistaken for the operator's local time
- retain the exact ISO timestamp in the semantic time element and tooltip

## Verification
- ControlRoom controller tests: 5 runs, 32 assertions, 0 failures
- live Chrome inspection identified the UTC/local mismatch