### PR TITLE
fix: make Control Room cockpit live

### DIFF
--- a/app/controllers/control_room_controller.rb
+++ b/app/controllers/control_room_controller.rb
@@ -2,17 +2,17 @@
 
 class ControlRoomController < ApplicationController
   before_action :set_task, only: %i[thread message approve retry cancel]
-  helper_method :pane_display_status
+  helper_method :intent_result_summary, :pane_display_status
 
   def show
     @full_width_page = true
-    @sources = current_user.orchestration_sources.most_recent
-    @source = selected_source(@sources)
-    @project_options = project_options(@source)
-    @tasks = projected_tasks.includes(:agent_messages).order(updated_at: :desc).limit(250)
-    @pending_intents = current_user.orchestration_intents.pending.limit(100)
-    categorize_tasks
+    load_control_room_state
     @selected_task = selected_task
+  end
+
+  def live
+    load_control_room_state
+    render partial: "live_payload"
   end
 
   def create_task
@@ -56,6 +56,16 @@ class ControlRoomController < ApplicationController
 
   private
 
+  def load_control_room_state
+    @sources = current_user.orchestration_sources.most_recent
+    @source = selected_source(@sources)
+    @project_options = project_options(@source)
+    @tasks = projected_tasks.includes(:agent_messages).order(updated_at: :desc).limit(250)
+    @pending_intents = current_user.orchestration_intents.pending.limit(100)
+    @recent_intents = current_user.orchestration_intents.recent.limit(12)
+    categorize_tasks
+  end
+
   def projected_tasks
     current_user.tasks.where("origin_session_key LIKE 'wezbridge:%'")
   end
@@ -80,6 +90,12 @@ class ControlRoomController < ApplicationController
   def pane_display_status(pane)
     status = (pane["status"] || pane["state"]).to_s
     status.blank? || status == "unknown" ? "present" : status
+  end
+
+  def intent_result_summary(intent)
+    result = intent.result.to_h
+    summary = result["reason"] || result["error"] || result["message"]
+    Orchestration::PayloadSanitizer.text(summary, maximum: 200).presence
   end
 
   def categorize_tasks

--- a/app/javascript/controllers/control_room_live_controller.js
+++ b/app/javascript/controllers/control_room_live_controller.js
@@ -1,0 +1,49 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["status"]
+  static values = { interval: { type: Number, default: 5000 }, url: String }
+
+  connect() {
+    this.refresh()
+    this.timer = setInterval(() => this.refresh(), this.intervalValue)
+  }
+
+  disconnect() {
+    clearInterval(this.timer)
+  }
+
+  async refresh() {
+    if (this.inFlight || document.hidden) return
+
+    this.inFlight = true
+    try {
+      const response = await fetch(this.urlValue, { headers: { Accept: "text/html" }, cache: "no-store" })
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      this.updateRegions(await response.text())
+      this.setStatus("Live cockpit · updated just now", "text-green-400")
+    } catch (_error) {
+      this.setStatus("Live cockpit update delayed", "text-yellow-400")
+    } finally {
+      this.inFlight = false
+    }
+  }
+
+  updateRegions(html) {
+    const next = document.createElement("div")
+    next.innerHTML = html
+    next.querySelectorAll("[data-control-room-live-region]").forEach((region) => {
+      const name = region.dataset.controlRoomLiveRegion
+      const current = [...this.element.querySelectorAll("[data-control-room-live-region]")]
+        .find((candidate) => candidate.dataset.controlRoomLiveRegion === name)
+      if (current) current.innerHTML = region.innerHTML
+    })
+  }
+
+  setStatus(message, tone) {
+    if (!this.hasStatusTarget) return
+    this.statusTarget.textContent = message
+    this.statusTarget.classList.remove("text-green-400", "text-yellow-400")
+    this.statusTarget.classList.add(tone)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -52,6 +52,7 @@ import ZerobitchFleetController from "controllers/zerobitch_fleet_controller"
 import ZerobitchSpawnController from "controllers/zerobitch_spawn_controller"
 import ZerobitchAgentController from "controllers/zerobitch_agent_controller"
 import ActiveFlowsController from "controllers/active_flows_controller"
+import ControlRoomLiveController from "controllers/control_room_live_controller"
 import ControlRoomThreadController from "controllers/control_room_thread_controller"
 
 application.register("notifications", NotificationsController)
@@ -101,6 +102,7 @@ application.register("zerobitch-fleet", ZerobitchFleetController)
 application.register("zerobitch-spawn", ZerobitchSpawnController)
 application.register("zerobitch-agent", ZerobitchAgentController)
 application.register("active-flows", ActiveFlowsController)
+application.register("control-room-live", ControlRoomLiveController)
 application.register("control-room-thread", ControlRoomThreadController)
 
 import ThemeToggleController from "controllers/theme_toggle_controller"

--- a/app/views/control_room/_fleet.html.erb
+++ b/app/views/control_room/_fleet.html.erb
@@ -1,0 +1,30 @@
+<section class="rounded-xl border border-border bg-bg-surface p-4" data-control-room-live-region="fleet">
+  <div class="flex items-center justify-between gap-3">
+    <div>
+      <h2 class="text-sm font-semibold text-content">Fleet</h2>
+      <p class="mt-1 text-xs text-content-muted">
+        <% if @source&.last_seen_at %>
+          <%= @source.panes.length %> visible panes · last sync <%= time_ago_in_words(@source.last_seen_at) %> ago
+        <% else %>
+          No bridge telemetry yet
+        <% end %>
+      </p>
+    </div>
+    <% if @source&.health&.dig("fleet") %>
+      <% a2a_updates = @source.health.dig("fleet", "a2a_envelopes").to_i %>
+      <span class="text-xs text-content-muted">
+        <%= a2a_updates.positive? ? "#{a2a_updates} A2A updates in latest sync" : "No A2A updates in latest sync" %>
+      </span>
+    <% end %>
+  </div>
+  <% if @source&.panes&.any? %>
+    <div class="mt-3 flex flex-wrap gap-2">
+      <% @source.panes.each do |pane| %>
+        <span class="rounded-lg border border-border bg-bg-elevated px-3 py-2 text-xs text-content-secondary">
+          pane <%= pane["pane_id"] || pane["id"] %>
+          <span class="ml-1 text-content-muted"><%= pane["project"] %> · <%= pane_display_status(pane) %></span>
+        </span>
+      <% end %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/control_room/_live_payload.html.erb
+++ b/app/views/control_room/_live_payload.html.erb
@@ -1,0 +1,4 @@
+<%= render "source_badges" %>
+<%= render "fleet" %>
+<%= render "request_status" %>
+<%= render "task_board" %>

--- a/app/views/control_room/_request_status.html.erb
+++ b/app/views/control_room/_request_status.html.erb
@@ -1,0 +1,33 @@
+<section class="rounded-xl border border-border bg-bg-surface p-4" data-control-room-live-region="requests">
+  <div class="flex items-center justify-between gap-3">
+    <div>
+      <h2 class="text-sm font-semibold text-content">Recent requests</h2>
+      <p class="mt-1 text-xs text-content-muted">What the PC bridge accepted, rejected, or is still processing.</p>
+    </div>
+    <% if @pending_intents.any? %>
+      <span class="rounded-full bg-accent/15 px-2 py-1 text-xs font-semibold text-accent">
+        <%= pluralize(@pending_intents.size, "pending") %>
+      </span>
+    <% end %>
+  </div>
+
+  <% if @recent_intents.any? %>
+    <div class="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+      <% @recent_intents.each do |intent| %>
+        <% tone = { "applied" => "border-green-400/25 text-green-400", "rejected" => "border-red-400/25 text-red-400" }.fetch(intent.status, "border-accent/25 text-accent") %>
+        <div class="rounded-lg border bg-bg-elevated px-3 py-2 <%= tone %>">
+          <div class="flex items-center justify-between gap-3 text-xs">
+            <span class="font-semibold">#<%= intent.id %> <%= intent.kind.humanize %></span>
+            <span><%= intent.status.humanize %></span>
+          </div>
+          <p class="mt-1 text-xs text-content-muted">
+            <%= intent_result_summary(intent) || (intent.status == "pending" ? "Waiting for Wezbridge" : "Processed by Wezbridge") %>
+            · <%= time_ago_in_words(intent.processed_at || intent.created_at) %> ago
+          </p>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="mt-3 text-sm text-content-muted">No requests have been sent yet.</p>
+  <% end %>
+</section>

--- a/app/views/control_room/_source_badges.html.erb
+++ b/app/views/control_room/_source_badges.html.erb
@@ -1,0 +1,19 @@
+<div class="flex flex-wrap gap-2" data-control-room-live-region="source-badges">
+  <% if @sources.any? %>
+    <% @sources.each do |source| %>
+      <% status_class = source.stale? ? "text-yellow-400 border-yellow-400/30 bg-yellow-400/10" : "text-green-400 border-green-400/30 bg-green-400/10" %>
+      <%= link_to control_room_path(source_id: source.id),
+            class: "rounded-lg border px-3 py-2 text-xs #{status_class}" do %>
+        <span class="font-semibold"><%= source.profile %></span>
+        <span class="ml-1"><%= source.display_status %></span>
+        <% if source.last_seen_at %>
+          <span class="ml-1 text-content-muted"><%= time_ago_in_words(source.last_seen_at) %> ago</span>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <span class="rounded-lg border border-yellow-400/30 bg-yellow-400/10 px-3 py-2 text-xs text-yellow-400">
+      Waiting for the Wezbridge bridge
+    </span>
+  <% end %>
+</div>

--- a/app/views/control_room/_task_board.html.erb
+++ b/app/views/control_room/_task_board.html.erb
@@ -1,0 +1,6 @@
+<section class="grid gap-4 xl:grid-cols-4" data-control-room-live-region="task-board">
+  <%= render "task_list", title: "Needs Attention", tasks: @needs_attention, tone: "yellow" %>
+  <%= render "task_list", title: "Active Work", tasks: @active, tone: "blue" %>
+  <%= render "task_list", title: "Failures", tasks: @failures, tone: "red" %>
+  <%= render "task_list", title: "Recently Completed", tasks: @recent, tone: "green" %>
+</section>

--- a/app/views/control_room/show.html.erb
+++ b/app/views/control_room/show.html.erb
@@ -1,6 +1,9 @@
 <% content_for :title, "Control Room" %>
 <% content_for :breadcrumb_standalone, "Control Room" %>
-<div class="py-8 space-y-6">
+<div class="space-y-6 py-6"
+     data-controller="control-room-live"
+     data-control-room-live-url-value="<%= control_room_live_path(source_id: @source&.id) %>"
+     data-control-room-live-interval-value="5000">
   <header class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
     <div>
       <p class="text-xs font-semibold uppercase tracking-[0.2em] text-accent">Personal orchestration</p>
@@ -8,59 +11,15 @@
       <p class="mt-2 max-w-2xl text-sm text-content-secondary">
         Create work, talk to the orchestrator, and watch the local fleet without managing every terminal tab.
       </p>
+      <p class="mt-2 text-xs text-content-muted"
+         data-control-room-live-target="status"
+         aria-live="polite">Connecting live cockpit…</p>
     </div>
 
-    <div class="flex flex-wrap gap-2">
-      <% if @sources.any? %>
-        <% @sources.each do |source| %>
-          <% status_class = source.stale? ? "text-yellow-400 border-yellow-400/30 bg-yellow-400/10" : "text-green-400 border-green-400/30 bg-green-400/10" %>
-          <%= link_to control_room_path(source_id: source.id),
-                class: "rounded-lg border px-3 py-2 text-xs #{status_class}" do %>
-            <span class="font-semibold"><%= source.profile %></span>
-            <span class="ml-1"><%= source.display_status %></span>
-            <% if source.last_seen_at %>
-              <span class="ml-1 text-content-muted"><%= time_ago_in_words(source.last_seen_at) %> ago</span>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% else %>
-        <span class="rounded-lg border border-yellow-400/30 bg-yellow-400/10 px-3 py-2 text-xs text-yellow-400">
-          Waiting for the Wezbridge bridge
-        </span>
-      <% end %>
-    </div>
+    <%= render "source_badges" %>
   </header>
 
-  <section class="rounded-xl border border-border bg-bg-surface p-4">
-    <div class="flex items-center justify-between gap-3">
-      <div>
-        <h2 class="text-sm font-semibold text-content">Fleet</h2>
-        <p class="mt-1 text-xs text-content-muted">
-          <% if @source&.last_seen_at %>
-            <%= @source.panes.length %> visible panes · last sync <%= time_ago_in_words(@source.last_seen_at) %> ago
-          <% else %>
-            No bridge telemetry yet
-          <% end %>
-        </p>
-      </div>
-      <% if @source&.health&.dig("fleet") %>
-        <% a2a_updates = @source.health.dig("fleet", "a2a_envelopes").to_i %>
-        <span class="text-xs text-content-muted">
-          <%= a2a_updates.positive? ? "#{a2a_updates} A2A updates in latest sync" : "No A2A updates in latest sync" %>
-        </span>
-      <% end %>
-    </div>
-    <% if @source&.panes&.any? %>
-      <div class="mt-3 flex flex-wrap gap-2">
-        <% @source.panes.each do |pane| %>
-          <span class="rounded-lg border border-border bg-bg-elevated px-3 py-2 text-xs text-content-secondary">
-            pane <%= pane["pane_id"] || pane["id"] %>
-            <span class="ml-1 text-content-muted"><%= pane["project"] %> · <%= pane_display_status(pane) %></span>
-          </span>
-        <% end %>
-      </div>
-    <% end %>
-  </section>
+  <%= render "fleet" %>
 
   <section class="grid gap-4 lg:grid-cols-2">
     <div class="rounded-xl border border-border bg-bg-surface p-5">
@@ -125,25 +84,8 @@
     </div>
   </section>
 
-  <% if @pending_intents.any? %>
-    <section class="rounded-xl border border-accent/30 bg-accent/5 p-4">
-      <h2 class="text-sm font-semibold text-content">Queued requests</h2>
-      <div class="mt-2 flex flex-wrap gap-2">
-        <% @pending_intents.each do |intent| %>
-          <span class="rounded-md border border-accent/20 bg-bg-elevated px-2 py-1 text-xs text-content-secondary">
-            #<%= intent.id %> <%= intent.kind.humanize %>
-          </span>
-        <% end %>
-      </div>
-    </section>
-  <% end %>
-
-  <section class="grid gap-4 xl:grid-cols-4">
-    <%= render "task_list", title: "Needs Attention", tasks: @needs_attention, tone: "yellow" %>
-    <%= render "task_list", title: "Active Work", tasks: @active, tone: "blue" %>
-    <%= render "task_list", title: "Failures", tasks: @failures, tone: "red" %>
-    <%= render "task_list", title: "Recently Completed", tasks: @recent, tone: "green" %>
-  </section>
+  <%= render "request_status" %>
+  <%= render "task_board" %>
 
   <% if @selected_task %>
     <% state = @selected_task.state_data.fetch("orchestration", {}) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,6 +258,7 @@ Rails.application.routes.draw do
   end
 
   get "control-room", to: "control_room#show", as: :control_room
+  get "control-room/live", to: "control_room#live", as: :control_room_live
   get "control-room/tasks/:task_id/thread", to: "control_room#thread", as: :control_room_task_thread
   post "control-room/tasks", to: "control_room#create_task", as: :control_room_tasks
   post "control-room/ask", to: "control_room#ask", as: :control_room_ask

--- a/test/controllers/control_room_controller_test.rb
+++ b/test/controllers/control_room_controller_test.rb
@@ -73,6 +73,9 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", "Control Room"
     assert_select "main#main-content.w-full.max-w-none"
+    assert_select "[data-controller='control-room-live']", count: 1
+    assert_select "[data-control-room-live-region='requests']", count: 1
+    assert_select "h2", "Recent requests"
     assert_select "[data-controller='gateway-health']", count: 0
     assert_select "select#task_project", count: 1
     assert_select "select#question_project", count: 1
@@ -87,6 +90,40 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
       origin_session_key: "wezbridge:primary:task:T-OTHER")
     post control_room_task_messages_path(other), params: { content: "No access" }
     assert_response :not_found
+  end
+
+  test "renders live cockpit regions with durable request outcomes" do
+    task = projected_task
+    applied = @user.orchestration_intents.create!(
+      orchestration_source: @source,
+      task:,
+      kind: "message",
+      status: "applied",
+      processed_at: Time.current,
+      result: { "message" => "Delivered to the ledger" }
+    )
+    @user.orchestration_intents.create!(
+      orchestration_source: @source,
+      task:,
+      kind: "cancel",
+      status: "rejected",
+      processed_at: Time.current,
+      result: { "reason" => "Task is already complete" }
+    )
+    sign_in_as(@user)
+
+    get control_room_live_path(source_id: @source.id)
+
+    assert_response :success
+    assert_select "[data-control-room-live-region]", count: 4
+    assert_select "[data-control-room-live-region='requests']", text: /##{applied.id} Message/
+    assert_includes response.body, "Delivered to the ledger"
+    assert_includes response.body, "Task is already complete"
+  end
+
+  test "live cockpit requires authentication" do
+    get control_room_live_path
+    assert_response :redirect
   end
 
   test "renders an owned task thread fragment and hides another user's task" do

--- a/test/system/control_room_test.rb
+++ b/test/system/control_room_test.rb
@@ -68,4 +68,29 @@ class ControlRoomTest < ApplicationSystemTestCase
       assert_text "Reply appeared through live refresh.", wait: 8
     end
   end
+
+  test "refreshes cockpit state without clearing a draft" do
+    visit control_room_path
+    fill_in "Task title", with: "Keep this draft"
+
+    @user.tasks.create!(
+      board: boards(:one),
+      name: "Appeared without a reload",
+      description: "Live dashboard proof.",
+      origin_session_id: "T-0002",
+      origin_session_key: "wezbridge:primary:task:T-0002",
+      status: :in_progress,
+      state_data: {
+        "orchestration" => {
+          "profile" => "primary",
+          "source_state" => "running",
+          "project" => "wezbridge"
+        }
+      }
+    )
+
+    assert_text "Appeared without a reload", wait: 8
+    assert_field "Task title", with: "Keep this draft"
+    assert_text "Live cockpit · updated just now"
+  end
 end


### PR DESCRIPTION
## What changed
- refresh fleet, source, request outcomes, and task columns every five seconds
- preserve in-progress form drafts while dashboard regions update
- keep recent applied/rejected request outcomes visible instead of disappearing
- add focused controller and Chrome system coverage

## Local verification
- 7 controller tests, 43 assertions, 0 failures
- focused RuboCop clean
- JavaScript syntax check clean

Tracks claw-8d9.