### PR TITLE
fix: deliver fleet questions to the orchestrator

### DIFF
--- a/app/controllers/control_room_controller.rb
+++ b/app/controllers/control_room_controller.rb
@@ -24,7 +24,7 @@ class ControlRoomController < ApplicationController
   end
 
   def ask
-    create_task_intent(kind: "question")
+    create_task_intent(kind: "question", default_project: "_fleet")
   end
 
   def message
@@ -60,6 +60,7 @@ class ControlRoomController < ApplicationController
     @sources = current_user.orchestration_sources.most_recent
     @source = selected_source(@sources)
     @project_options = project_options(@source)
+    @question_options = [["All open panes — fleet assessment", "_fleet"], *@project_options]
     @tasks = projected_tasks.includes(:agent_messages).order(updated_at: :desc).limit(250)
     @pending_intents = current_user.orchestration_intents.pending.limit(100)
     @recent_intents = current_user.orchestration_intents.recent.limit(12)
@@ -111,14 +112,15 @@ class ControlRoomController < ApplicationController
     @tasks.find { |task| task.id == params[:task_id].to_i }
   end
 
-  def create_task_intent(kind:)
+  def create_task_intent(kind:, default_project: nil)
     source = source_for_create!
     brief = required_param(:brief, maximum: 2_000)
     title = params[:title].to_s.strip.presence || brief.truncate(120)
     payload = {
       "title" => title.truncate(500),
       "brief" => brief,
-      "project" => required_param(:project, maximum: 200),
+      "project" => params[:project].to_s.strip.presence || default_project ||
+        required_param(:project, maximum: 200),
       "kind" => kind,
       "priority" => params[:priority].presence || "normal",
       "acceptance" => params[:acceptance].to_s.strip.truncate(2_000)

--- a/app/views/control_room/show.html.erb
+++ b/app/views/control_room/show.html.erb
@@ -25,7 +25,7 @@
     <div class="rounded-xl border border-border bg-bg-surface p-5">
       <h2 class="text-lg font-semibold text-content">New Task</h2>
       <p class="mt-1 text-xs text-content-muted">
-        Choose a pane's project context. Wezbridge validates the task and decides who runs it.
+        Record validated work in the durable ledger. Pane 0 dispatches it to a worker.
       </p>
       <%= form_with url: control_room_tasks_path, class: "mt-4 grid gap-3" do |form| %>
         <%= form.hidden_field :source_id, value: @source&.id, id: "task_source_id" %>
@@ -59,15 +59,14 @@
     <div class="rounded-xl border border-border bg-bg-surface p-5">
       <h2 class="text-lg font-semibold text-content">Ask Orchestrator</h2>
       <p class="mt-1 text-xs text-content-muted">
-        Ask pane 0 about the selected pane's project. The answer appears in the task thread.
+        Ask pane 0 about one project or the whole live fleet. The answer appears in the task thread.
       </p>
       <%= form_with url: control_room_ask_path, class: "mt-4 grid gap-3" do |form| %>
         <%= form.hidden_field :source_id, value: @source&.id, id: "question_source_id" %>
         <div>
           <%= form.label :project, "Question context", for: "question_project", class: "mb-1 block text-xs font-medium text-content-secondary" %>
-          <%= form.select :project, @project_options, { prompt: "Choose a live pane / project" },
+          <%= form.select :project, @question_options, { include_blank: false },
                 id: "question_project",
-                required: true,
                 class: "w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
         </div>
         <%= form.label :title, "Question title", for: "question_title", class: "sr-only" %>

--- a/test/controllers/control_room_controller_test.rb
+++ b/test/controllers/control_room_controller_test.rb
@@ -36,10 +36,11 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
 
     post control_room_ask_path, params: {
       source_id: @source.id,
-      project: "wezbridge",
       brief: "What should we improve next?"
     }
-    assert_equal "question", @user.orchestration_intents.last.payload["kind"]
+    question_intent = @user.orchestration_intents.last
+    assert_equal "question", question_intent.payload["kind"]
+    assert_equal "_fleet", question_intent.payload["project"]
   end
 
   test "records operator message before bridge delivery" do
@@ -79,6 +80,9 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-controller='gateway-health']", count: 0
     assert_select "select#task_project", count: 1
     assert_select "select#question_project", count: 1
+    assert_select "select#question_project" do |select|
+      assert_equal "_fleet", select.first.css("option").first["value"]
+    end
     assert_select "option[value='whatsappbot']", text: /pane 5/, count: 2
     assert_select "option[value='omniremote']", text: /present/, count: 2
     assert_includes response.body, "No A2A updates in latest sync"

--- a/test/system/control_room_test.rb
+++ b/test/system/control_room_test.rb
@@ -53,6 +53,22 @@ class ControlRoomTest < ApplicationSystemTestCase
     assert_equal %w[create_task message], @user.orchestration_intents.order(:id).pluck(:kind)
   end
 
+  test "asks pane 0 for a fleet assessment without choosing one project" do
+    visit control_room_path
+
+    within("form[action='#{control_room_ask_path}']") do
+      assert_equal "_fleet", find_field("Question context").value
+      fill_in "Question title", with: "Assess every open pane"
+      fill_in "Question", with: "Recommend the next action for every live project."
+      click_button "Ask"
+    end
+
+    assert_text "Question queued as intent"
+    intent = @user.orchestration_intents.order(:id).last
+    assert_equal "_fleet", intent.payload["project"]
+    assert_equal "question", intent.payload["kind"]
+  end
+
   test "shows a new orchestrator reply without reloading the page" do
     visit control_room_path(task_id: @task.id, anchor: "task-thread")
     assert_text "Live updates on"


### PR DESCRIPTION
Closes claw-slx.

Makes fleet assessment the default Ask Orchestrator context and adds authenticated system/controller coverage. The paired Wezbridge change binds the created question to a task and wakes pane 0 exactly once.