### PR TITLE
fix: make Control Room attention state truthful

### DIFF
--- a/app/controllers/control_room_controller.rb
+++ b/app/controllers/control_room_controller.rb
@@ -2,7 +2,8 @@
 
 class ControlRoomController < ApplicationController
   before_action :set_task, only: %i[thread message approve retry cancel]
-  helper_method :intent_result_summary, :pane_display_status
+  helper_method :intent_result_summary, :pane_display_status, :orchestration_items,
+    :task_needs_attention?
 
   def show
     @full_width_page = true
@@ -93,6 +94,21 @@ class ControlRoomController < ApplicationController
     status.blank? || status == "unknown" ? "present" : status
   end
 
+  def orchestration_items(value)
+    Array.wrap(value).flat_map do |item|
+      item.is_a?(Hash) ? item.map { |key, detail| "#{key}: #{detail}" } : item.to_s
+    end.reject(&:blank?)
+  end
+
+  def task_needs_attention?(task)
+    state = task.state_data.fetch("orchestration", {})
+    task[:blocked] || # Mirrored FSM blocker; blocked? only checks dependency rows.
+      task.blocked? ||
+      task[:needs_decision] || # Canonical decision flag; the enum value is a legacy fallback.
+      task.status == "needs_decision" ||
+      (state["kind"] == "question" && !%w[done cancelled].include?(state["source_state"]))
+  end
+
   def intent_result_summary(intent)
     result = intent.result.to_h
     summary = result["reason"] || result["error"] || result["message"]
@@ -100,9 +116,11 @@ class ControlRoomController < ApplicationController
   end
 
   def categorize_tasks
-    @needs_attention = @tasks.select { |task| task.blocked? || task.needs_decision? }
+    @needs_attention = @tasks.select { |task| task_needs_attention?(task) }
     @failures = @tasks.select { |task| source_state(task) == "failed" }
-    @active = @tasks.select { |task| %w[queued ready running review].include?(source_state(task)) && !task.blocked? }
+    @active = @tasks.select do |task|
+      %w[queued ready running review].include?(source_state(task)) && !task_needs_attention?(task)
+    end
     @recent = @tasks.select { |task| %w[done cancelled].include?(source_state(task)) }.first(25)
   end
 

--- a/app/services/orchestration/sync_ingestor.rb
+++ b/app/services/orchestration/sync_ingestor.rb
@@ -139,6 +139,9 @@ module Orchestration
             "lease" => snapshot[:lease],
             "acceptance" => snapshot[:acceptance],
             "evidence" => snapshot[:evidence],
+            "contract" => snapshot[:contract],
+            "corr" => snapshot[:corr],
+            "context_refs" => snapshot[:context_refs],
             "source_updated_at" => snapshot[:updated_at]
           }
         )

--- a/app/views/control_room/_fleet.html.erb
+++ b/app/views/control_room/_fleet.html.erb
@@ -20,10 +20,20 @@
   <% if @source&.panes&.any? %>
     <div class="mt-3 flex flex-wrap gap-2">
       <% @source.panes.each do |pane| %>
-        <span class="rounded-lg border border-border bg-bg-elevated px-3 py-2 text-xs text-content-secondary">
-          pane <%= pane["pane_id"] || pane["id"] %>
+        <div class="rounded-lg border border-border bg-bg-elevated px-3 py-2 text-xs text-content-secondary">
+          <span class="font-semibold">pane <%= pane["pane_id"] || pane["id"] %></span>
           <span class="ml-1 text-content-muted"><%= pane["project"] %> · <%= pane_display_status(pane) %></span>
-        </span>
+          <% if pane["title"].present? || pane["model"].present? || pane["ctx"].present? %>
+            <p class="mt-1 text-[11px] text-content-muted">
+              <%= [pane["title"], pane["persona"], pane["model"], pane["ctx"]].compact_blank.join(" · ") %>
+            </p>
+          <% end %>
+          <% if pane["session_pct"].present? || pane["weekly_pct"].present? %>
+            <p class="mt-1 text-[11px] text-content-muted">
+              Session <%= pane["session_pct"].presence || "—" %>% · week <%= pane["weekly_pct"].presence || "—" %>%
+            </p>
+          <% end %>
+        </div>
       <% end %>
     </div>
   <% end %>

--- a/app/views/control_room/_live_payload.html.erb
+++ b/app/views/control_room/_live_payload.html.erb
@@ -1,4 +1,5 @@
 <%= render "source_badges" %>
+<%= render "source_health" %>
 <%= render "fleet" %>
 <%= render "request_status" %>
 <%= render "task_board" %>

--- a/app/views/control_room/_source_badges.html.erb
+++ b/app/views/control_room/_source_badges.html.erb
@@ -1,11 +1,12 @@
 <div class="flex flex-wrap gap-2" data-control-room-live-region="source-badges">
   <% if @sources.any? %>
     <% @sources.each do |source| %>
-      <% status_class = source.stale? ? "text-yellow-400 border-yellow-400/30 bg-yellow-400/10" : "text-green-400 border-green-400/30 bg-green-400/10" %>
+      <% unhealthy = source.stale? || source.health.to_h["stalled"] == true || source.last_error.present? %>
+      <% status_class = unhealthy ? "text-red-300 border-red-400/40 bg-red-400/10" : "text-green-400 border-green-400/30 bg-green-400/10" %>
       <%= link_to control_room_path(source_id: source.id),
             class: "rounded-lg border px-3 py-2 text-xs #{status_class}" do %>
         <span class="font-semibold"><%= source.profile %></span>
-        <span class="ml-1"><%= source.display_status %></span>
+        <span class="ml-1"><%= unhealthy ? "attention" : source.display_status %></span>
         <% if source.last_seen_at %>
           <span class="ml-1 text-content-muted"><%= time_ago_in_words(source.last_seen_at) %> ago</span>
         <% end %>

--- a/app/views/control_room/_source_health.html.erb
+++ b/app/views/control_room/_source_health.html.erb
@@ -1,0 +1,27 @@
+<% health = @source&.health.to_h %>
+<% stalled = health["stalled"] == true %>
+<% stale = @source&.stale? || stalled %>
+<% last_error = @source&.last_error.presence %>
+<% warning = stale || last_error.present? %>
+<section data-control-room-live-region="source-health"
+         class="<%= warning ? "rounded-xl border border-red-400/40 bg-red-400/10 p-4" : "hidden" %>"
+         role="<%= warning ? "alert" : "status" %>">
+  <% if warning %>
+    <h2 class="text-sm font-semibold text-red-300">
+      <%= stalled ? "Orchestration bridge is stalled" : "Orchestration updates are delayed" %>
+    </h2>
+    <p class="mt-1 text-sm text-red-200">
+      This board may be showing old state.
+      <% if health["stale_seconds"].present? %>
+        No progress for <%= distance_of_time_in_words(health["stale_seconds"].to_i) %>.
+      <% elsif @source&.last_seen_at %>
+        Last sync was <%= time_ago_in_words(@source.last_seen_at) %> ago.
+      <% else %>
+        No successful sync has been recorded.
+      <% end %>
+    </p>
+    <% if last_error %>
+      <p class="mt-2 break-words text-xs text-red-200"><span class="font-semibold">Bridge error:</span> <%= last_error %></p>
+    <% end %>
+  <% end %>
+</section>

--- a/app/views/control_room/_task_context.html.erb
+++ b/app/views/control_room/_task_context.html.erb
@@ -1,0 +1,23 @@
+<% contract = state["contract"].to_h %>
+<% gate = contract["gate"].presence || contract["kind"].presence %>
+<% fields = [
+     ["Blocked by", state["blocker"]],
+     ["Gate", gate],
+     ["Next action", state["next_action"]],
+     ["Acceptance", state["acceptance"]],
+     ["Evidence", state["evidence"]]
+   ] %>
+<% visible_fields = fields.select { |_label, value| orchestration_items(value).any? } %>
+
+<% if visible_fields.any? %>
+  <dl class="<%= compact ? "mt-3 space-y-2 border-t border-border pt-2" : "mt-4 grid gap-3 md:grid-cols-2" %>">
+    <% visible_fields.each do |label, value| %>
+      <div class="<%= compact ? "" : "rounded-lg border border-border bg-bg-elevated p-3" %>">
+        <dt class="text-[11px] font-semibold uppercase tracking-wider text-content-muted"><%= label %></dt>
+        <% orchestration_items(value).each do |item| %>
+          <dd class="mt-1 whitespace-pre-wrap text-xs text-content-secondary"><%= item %></dd>
+        <% end %>
+      </div>
+    <% end %>
+  </dl>
+<% end %>

--- a/app/views/control_room/_task_list.html.erb
+++ b/app/views/control_room/_task_list.html.erb
@@ -1,17 +1,28 @@
-<section class="min-h-40 rounded-xl border border-border bg-bg-surface p-4">
+<section class="min-h-40 rounded-xl border border-border bg-bg-surface p-4"
+         data-board-section="<%= title.parameterize %>"
+         data-source-count="<%= tasks.length %>"
+         data-rendered-count="<%= [tasks.length, 20].min %>">
   <div class="flex items-center justify-between gap-2">
     <h2 class="text-sm font-semibold text-content"><%= title %></h2>
-    <span class="rounded-full bg-bg-elevated px-2 py-0.5 text-xs text-content-muted"><%= tasks.length %></span>
+    <span class="rounded-full bg-bg-elevated px-2 py-0.5 text-xs text-content-muted">
+      <%= tasks.length > 20 ? "#{[tasks.length, 20].min} of #{tasks.length}" : tasks.length %>
+    </span>
   </div>
   <div class="mt-3 space-y-2">
     <% tasks.first(20).each do |task| %>
       <% state = task.state_data.fetch("orchestration", {}) %>
-      <%= link_to control_room_path(task_id: task.id), class: "block rounded-lg border border-border bg-bg-elevated p-3 transition-colors hover:border-accent/40" do %>
-        <p class="truncate text-sm font-medium text-content"><%= task.name %></p>
+      <%= link_to control_room_path(task_id: task.id, anchor: "task-thread"),
+            class: "block rounded-lg border border-border bg-bg-elevated p-3 transition-colors hover:border-accent/40",
+            data: { task_origin_id: task.origin_session_id } do %>
+        <p class="text-sm font-medium text-content"><%= task.name %></p>
         <div class="mt-1 flex items-center justify-between gap-2 text-xs text-content-muted">
           <span class="truncate"><%= state["project"] %></span>
           <span><%= state["source_state"] %></span>
         </div>
+        <%= render "task_context", state:, compact: true %>
+        <% if task_needs_attention?(task) %>
+          <p class="mt-3 text-xs font-semibold text-accent">Open and answer</p>
+        <% end %>
       <% end %>
     <% end %>
     <% if tasks.empty? %>

--- a/app/views/control_room/show.html.erb
+++ b/app/views/control_room/show.html.erb
@@ -19,6 +19,7 @@
     <%= render "source_badges" %>
   </header>
 
+  <%= render "source_health" %>
   <%= render "fleet" %>
 
   <section class="grid gap-4 lg:grid-cols-2">
@@ -98,12 +99,13 @@
           <p class="text-xs uppercase tracking-wider text-content-muted"><%= state["project"] %> · <%= state["source_state"] %></p>
           <h2 class="mt-1 text-xl font-semibold text-content"><%= @selected_task.name %></h2>
           <p class="mt-2 whitespace-pre-wrap text-sm text-content-secondary"><%= @selected_task.description %></p>
+          <%= render "task_context", state:, compact: false %>
           <p class="mt-2 text-xs text-green-400"
              data-control-room-thread-target="status"
              aria-live="polite">Live updates on</p>
         </div>
         <div class="flex flex-wrap gap-2">
-          <% if @selected_task.blocked? || state["source_state"] == "review" %>
+          <% if task_needs_attention?(@selected_task) || state["source_state"] == "review" %>
             <%= button_to "Approve", approve_control_room_task_path(@selected_task), class: "rounded-lg bg-green-600 px-3 py-2 text-xs font-semibold text-white" %>
           <% end %>
           <% if state["source_state"] == "failed" %>

--- a/test/controllers/api/v1/orchestration_controller_test.rb
+++ b/test/controllers/api/v1/orchestration_controller_test.rb
@@ -46,8 +46,14 @@ class Api::V1::OrchestrationControllerTest < ActionDispatch::IntegrationTest
     assert_equal "in_progress", task.status
     refute task.assigned_to_agent?
     assert_equal "running", task.state_data.dig("orchestration", "source_state")
+    assert_equal "operator", task.state_data.dig("orchestration", "contract", "gate")
+    assert_equal "clawtrol-phase1", task.state_data.dig("orchestration", "corr")
+    assert_equal ["briefs/T-0001.md"], task.state_data.dig("orchestration", "context_refs")
     source = @user.orchestration_sources.find_by!(profile: "primary")
     assert_equal "healthy", source.status
+    assert_equal true, source.health["stalled"]
+    assert_equal 145, source.health["stale_seconds"]
+    assert_equal "codex", source.panes.first["model"]
     refute source.health.key?("token")
     assert_equal 1, run.run_number
     assert_equal 1, task.agent_activity_events.count
@@ -99,14 +105,15 @@ class Api::V1::OrchestrationControllerTest < ActionDispatch::IntegrationTest
     post sync_path, params: base_payload.to_json, headers: @headers
     assert_response :success
     source = @user.orchestration_sources.find_by!(profile: "primary")
-    assert_equal [{ "id" => 0, "state" => "idle" }], source.panes
+    expected_panes = [{ "id" => 0, "ctx" => "81%", "model" => "codex", "state" => "idle" }]
+    assert_equal expected_panes, source.panes
 
     delta = base_payload.except(:panes)
     delta[:generated_at] = "2026-07-27T20:00:05Z"
     post sync_path, params: delta.to_json, headers: @headers
     assert_response :success
 
-    assert_equal [{ "id" => 0, "state" => "idle" }], source.reload.panes
+    assert_equal expected_panes, source.reload.panes
   end
 
   test "keeps profiles isolated by authenticated user" do
@@ -137,8 +144,8 @@ class Api::V1::OrchestrationControllerTest < ActionDispatch::IntegrationTest
     {
       profile: "primary",
       generated_at: "2026-07-27T20:00:00Z",
-      health: { status: "ok", last_error: nil, token: "must-be-dropped" },
-      panes: [{ id: 0, state: "idle" }],
+      health: { status: "ok", last_error: nil, stalled: true, stale_seconds: 145, token: "must-be-dropped" },
+      panes: [{ id: 0, state: "idle", model: "codex", ctx: "81%" }],
       tasks: [],
       events: [],
       messages: [],
@@ -159,6 +166,14 @@ class Api::V1::OrchestrationControllerTest < ActionDispatch::IntegrationTest
       depends_on: [],
       acceptance: ["focused tests pass"],
       evidence: [],
+      contract: {
+        mode: "born_blocked",
+        gate: "operator",
+        allowed_paths: ["app/views/control_room/**"],
+        evaluator: "bin/rails test"
+      },
+      corr: "clawtrol-phase1",
+      context_refs: ["briefs/T-0001.md"],
       updated_at: "2026-07-27T20:00:05Z"
     }
   end

--- a/test/controllers/control_room_controller_test.rb
+++ b/test/controllers/control_room_controller_test.rb
@@ -119,10 +119,79 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     get control_room_live_path(source_id: @source.id)
 
     assert_response :success
-    assert_select "[data-control-room-live-region]", count: 4
+    assert_select "[data-control-room-live-region]", count: 5
     assert_select "[data-control-room-live-region='requests']", text: /##{applied.id} Message/
     assert_includes response.body, "Delivered to the ledger"
     assert_includes response.body, "Task is already complete"
+  end
+
+  test "needs attention is a truthful union and explains gated work" do
+    blocked = projected_task
+    blocked.update!(
+      name: "T-0022 judicial balance ruling",
+      state_data: blocked.state_data.deep_merge(
+        "orchestration" => {
+          "blocker" => "Operator must decide whether to dispose ARS 8,025,812.27.",
+          "next_action" => "Answer with approve or retain.",
+          "acceptance" => ["Decision is recorded"],
+          "evidence" => ["20 balances affect current members"],
+          "contract" => { "mode" => "born_blocked", "gate" => "operator" }
+        }
+      )
+    )
+    decision = projected_task_with(
+      id: "T-0023",
+      name: "T-0023 rotate exposed credential",
+      state: "queued",
+      needs_decision: true
+    )
+    question = projected_task_with(
+      id: "T-0024",
+      name: "Open operator question",
+      state: "queued",
+      kind: "question"
+    )
+    projected_task_with(id: "T-0025", name: "Completed question", state: "done", kind: "question", status: :done)
+    projected_task_with(id: "T-0026", name: "Normal active task", state: "running")
+    sign_in_as(@user)
+
+    get control_room_path(task_id: blocked.id)
+
+    assert_response :success
+    attention = css_select("[data-board-section='needs-attention']").sole
+    assert_equal "3", attention["data-source-count"]
+    assert_equal "3", attention["data-rendered-count"]
+    assert_equal 1, attention.css("[data-task-origin-id='#{blocked.origin_session_id}']").count
+    assert_equal 1, attention.css("[data-task-origin-id='#{decision.origin_session_id}']").count
+    assert_equal 1, attention.css("[data-task-origin-id='#{question.origin_session_id}']").count
+    assert_equal 0, attention.css("[data-task-origin-id='T-0025']").count
+    assert_includes attention.text, "Blocked by"
+    assert_includes attention.text, "ARS 8,025,812.27"
+    assert_includes attention.text, "Gate"
+    assert_includes attention.text, "operator"
+    assert_includes attention.text, "Next action"
+    assert_includes attention.text, "Acceptance"
+    assert_includes attention.text, "Evidence"
+    assert_select "#task-thread form[action='#{control_room_task_messages_path(blocked)}']", count: 1
+  end
+
+  test "renders a loud stalled bridge warning with its error" do
+    @source.update!(
+      last_seen_at: 5.minutes.ago,
+      last_error: "sync HTTP 503",
+      health: { "stalled" => true, "stale_seconds" => 305 }
+    )
+    sign_in_as(@user)
+
+    get control_room_path
+
+    assert_response :success
+    assert_select "[data-control-room-live-region='source-health'][role='alert']", count: 1 do
+      assert_select "h2", "Orchestration bridge is stalled"
+      assert_select "p", text: /board may be showing old state/i
+      assert_select "p", text: /sync HTTP 503/
+    end
+    assert_select "[data-control-room-live-region='source-badges']", text: /attention/
   end
 
   test "live cockpit requires authentication" do
@@ -168,6 +237,26 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
           "profile" => "primary",
           "source_state" => "blocked",
           "project" => "whatsappbot"
+        }
+      }
+    )
+  end
+
+  def projected_task_with(id:, name:, state:, kind: "task", status: :up_next, needs_decision: false)
+    @user.tasks.create!(
+      board: boards(:one),
+      name:,
+      description: "Immutable brief",
+      origin_session_id: id,
+      origin_session_key: "wezbridge:primary:task:#{id}",
+      status:,
+      needs_decision:,
+      state_data: {
+        "orchestration" => {
+          "profile" => "primary",
+          "source_state" => state,
+          "project" => "whatsappbot",
+          "kind" => kind
         }
       }
     )

--- a/test/system/control_room_test.rb
+++ b/test/system/control_room_test.rb
@@ -23,7 +23,12 @@ class ControlRoomTest < ApplicationSystemTestCase
         "orchestration" => {
           "profile" => "primary",
           "source_state" => "blocked",
-          "project" => "whatsappbot"
+          "project" => "whatsappbot",
+          "blocker" => "Operator ruling required before execution.",
+          "next_action" => "Answer in this thread.",
+          "acceptance" => ["Operator decision is recorded"],
+          "evidence" => ["The contract was evaluated"],
+          "contract" => { "mode" => "born_blocked", "gate" => "operator" }
         }
       }
     )
@@ -35,6 +40,11 @@ class ControlRoomTest < ApplicationSystemTestCase
 
     assert_text "Control Room"
     assert_text "pane 0"
+    within("[data-board-section='needs-attention']") do
+      assert_text "Operator ruling required before execution."
+      assert_text "Gate"
+      assert_text "operator"
+    end
     within("form[action='#{control_room_tasks_path}']") do
       select "pane 0 — wezbridge (idle)", from: "Work context"
       fill_in "title", with: "Ship a focused fix"

--- a/test/system/control_room_test.rb
+++ b/test/system/control_room_test.rb
@@ -42,7 +42,7 @@ class ControlRoomTest < ApplicationSystemTestCase
     assert_text "pane 0"
     within("[data-board-section='needs-attention']") do
       assert_text "Operator ruling required before execution."
-      assert_text "Gate"
+      assert_text(/gate/i)
       assert_text "operator"
     end
     within("form[action='#{control_room_tasks_path}']") do


### PR DESCRIPTION
## Summary
- include mirrored blockers, decision flags, and open questions in Needs Attention
- render blocker, gate, next action, acceptance, and evidence on cards and detail
- persist new contract/correlation context and surface pane metadata
- show a loud live-updating bridge stalled/error warning

## Verification
- 14 controller/API tests, 116 assertions, 0 failures/errors
- focused Control Room system flow, 9 assertions, 0 failures/errors
- RuboCop: 5 files, no offenses

## Scope
T-0028 / claw-xe1. No schema, auth, deployment, or legacy executor changes.