### PR TITLE
fix: compact Control Room task context cards

### DIFF
--- a/app/views/control_room/_task_context.html.erb
+++ b/app/views/control_room/_task_context.html.erb
@@ -10,14 +10,35 @@
 <% visible_fields = fields.select { |_label, value| orchestration_items(value).any? } %>
 
 <% if visible_fields.any? %>
-  <dl class="<%= compact ? "mt-3 space-y-2 border-t border-border pt-2" : "mt-4 grid gap-3 md:grid-cols-2" %>">
-    <% visible_fields.each do |label, value| %>
-      <div class="<%= compact ? "" : "rounded-lg border border-border bg-bg-elevated p-3" %>">
-        <dt class="text-[11px] font-semibold uppercase tracking-wider text-content-muted"><%= label %></dt>
-        <% orchestration_items(value).each do |item| %>
-          <dd class="mt-1 whitespace-pre-wrap text-xs text-content-secondary"><%= item %></dd>
-        <% end %>
-      </div>
-    <% end %>
-  </dl>
+  <% if compact %>
+    <dl class="mt-3 space-y-2 border-t border-border pt-2" data-task-context="compact">
+      <% visible_fields.each do |label, value| %>
+        <% items = orchestration_items(value) %>
+        <div>
+          <dt class="text-[11px] font-semibold uppercase tracking-wider text-content-muted"><%= label %></dt>
+          <% if label == "Acceptance" %>
+            <dd class="mt-1 text-xs text-content-secondary"><%= pluralize(items.length, "criterion") %></dd>
+          <% elsif label == "Evidence" %>
+            <dd class="mt-1 text-xs text-content-secondary"><%= pluralize(items.length, "evidence item") %></dd>
+          <% else %>
+            <dd class="mt-1 line-clamp-2 break-words whitespace-pre-wrap text-xs text-content-secondary"><%= items.first %></dd>
+            <% if items.length > 1 %>
+              <dd class="mt-1 text-[11px] text-content-muted">+<%= items.length - 1 %> more</dd>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </dl>
+  <% else %>
+    <dl class="mt-4 grid gap-3 md:grid-cols-2" data-task-context="full">
+      <% visible_fields.each do |label, value| %>
+        <div class="rounded-lg border border-border bg-bg-elevated p-3">
+          <dt class="text-[11px] font-semibold uppercase tracking-wider text-content-muted"><%= label %></dt>
+          <% orchestration_items(value).each do |item| %>
+            <dd class="mt-1 whitespace-pre-wrap text-xs text-content-secondary"><%= item %></dd>
+          <% end %>
+        </div>
+      <% end %>
+    </dl>
+  <% end %>
 <% end %>

--- a/test/controllers/control_room_controller_test.rb
+++ b/test/controllers/control_room_controller_test.rb
@@ -172,6 +172,16 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     assert_includes attention.text, "Next action"
     assert_includes attention.text, "Acceptance"
     assert_includes attention.text, "Evidence"
+    blocked_card = attention.css("[data-task-origin-id='#{blocked.origin_session_id}']").sole
+    assert_includes blocked_card.text, "1 criterion"
+    assert_includes blocked_card.text, "1 evidence item"
+    assert_not_includes blocked_card.text, "Decision is recorded"
+    assert_not_includes blocked_card.text, "20 balances affect current members"
+    assert_equal 3, blocked_card.css("[data-task-context='compact'] .line-clamp-2").count
+
+    full_context = css_select("#task-thread [data-task-context='full']").sole
+    assert_includes full_context.text, "Decision is recorded"
+    assert_includes full_context.text, "20 balances affect current members"
     assert_select "#task-thread form[action='#{control_room_task_messages_path(blocked)}']", count: 1
   end
 


### PR DESCRIPTION
## Summary
- cap blocker, gate, and next-action previews to two lines on board cards
- replace full acceptance/evidence bodies with honest item counts
- preserve every full field in the selected task thread

## Verification
- regression asserts compact cards omit full acceptance/evidence bodies
- regression asserts selected task detail retains full values
- live Chrome verification follows after hosted CI and immutable deployment