### PR TITLE
feat: replace Control Room with focus inbox

### DIFF
--- a/.claude/skills/deploy-to-vm/SKILL.md
+++ b/.claude/skills/deploy-to-vm/SKILL.md
@@ -7,9 +7,9 @@ trigger: /deploy-to-vm
 
 # deploy-to-vm
 
-Deploy one immutable web image to the private-LAN VM. This skill never builds
-on the host, pulls source into a VM checkout, starts a worker, or deploys a
-floating tag.
+Deploy one immutable web image to the private-LAN VM through the canonical
+host control plane. This skill never builds on the host, replaces the guarded
+Compose descriptor, starts a worker, or deploys a floating tag.
 
 ## Required input and host state
 
@@ -17,12 +17,14 @@ floating tag.
 - Image: `ghcr.io/wolverin0/clawtrol:${REVISION}`.
 - Local repository: clean and checked out at `REVISION`.
 - Host deployment directory: `$HOME/.local/share/clawtrol-deploy`.
-- Host secret environment: `$HOME/.config/clawtrol/runtime.env`, mode `0600`.
+- Canonical host environment: `$HOME/.local/share/clawtrol-deploy/release.env`,
+  mode `0600`; it contains both runtime values and `CLAWTROL_IMAGE`.
 - Restored-database migration evidence for this exact image revision.
 - Both retired systemd web units and the Solid Queue worker remain stopped.
 
-Never print, copy into the repository, or place the host runtime environment in
-command arguments. Docker Compose reads it from the host-side environment file.
+The retired `$HOME/.config/clawtrol/runtime.env` must not exist and must never
+be consumed. Never print or copy the canonical environment into the repository.
+An image promotion may change only its `CLAWTROL_IMAGE` line.
 
 ## Hard preflight
 
@@ -46,36 +48,50 @@ Run read-only host checks:
 
 ```bash
 ssh -o BatchMode=yes -o ConnectTimeout=8 "$CLAWTROL_VM" 'set -eu
-test -f "$HOME/.config/clawtrol/runtime.env"
-test "$(stat -c %a "$HOME/.config/clawtrol/runtime.env")" = 600
+deploy_dir="$HOME/.local/share/clawtrol-deploy"
+test -f "$deploy_dir/docker-compose.yml"
+test -f "$deploy_dir/release.env"
+test "$(stat -c %a "$deploy_dir/release.env")" = 600
+test ! -e "$HOME/.config/clawtrol/runtime.env"
+test "$(grep -c "^CLAWTROL_IMAGE=" "$deploy_dir/release.env")" = 1
+test "$(cd "$deploy_dir" && docker compose \
+  --env-file release.env -f docker-compose.yml config --services)" = clawdeck
 for unit in clawdeck-web.service clawtrol.service clawtrol-worker.service; do
   ! systemctl --user is-active --quiet "$unit"
 done'
 ```
 
-If the runtime environment is absent, permissions are broader than `0600`, a
-retired unit is active, CI is not green for the exact SHA, or restore evidence
-is missing, stop. Do not repair host secrets or start/stop services implicitly.
+If canonical files are absent, permissions are broader than `0600`, the retired
+environment still exists, the descriptor resolves to anything except the one
+`clawdeck` service, a retired unit is active, CI is not green for the exact SHA,
+or restore evidence is missing, stop. Do not repair host secrets, replace the
+guarded descriptor, or start/stop services implicitly.
 
 ## Stage the immutable release
 
-Copy only the Compose descriptor from the tested checkout:
+Pull the exact image and create a candidate environment by copying the current
+canonical file and changing only its image line:
 
 ```bash
-ssh "$CLAWTROL_VM" 'mkdir -p "$HOME/.local/share/clawtrol-deploy"'
-scp docker-compose.yml \
-  "$CLAWTROL_VM:~/.local/share/clawtrol-deploy/docker-compose.yml.next"
 ssh "$CLAWTROL_VM" "set -eu
 cd \"\$HOME/.local/share/clawtrol-deploy\"
-printf 'CLAWTROL_IMAGE=ghcr.io/wolverin0/clawtrol:%s\n' '$REVISION' > release.env.next
+test \"\$(grep -c '^CLAWTROL_IMAGE=' release.env)\" = 1
+cp release.env release.env.next
+sed -i 's|^CLAWTROL_IMAGE=.*$|CLAWTROL_IMAGE=ghcr.io/wolverin0/clawtrol:$REVISION|' \
+  release.env.next
 chmod 600 release.env.next
+before_nonimage=\"\$(grep -v '^CLAWTROL_IMAGE=' release.env | sha256sum | cut -d' ' -f1)\"
+after_nonimage=\"\$(grep -v '^CLAWTROL_IMAGE=' release.env.next | sha256sum | cut -d' ' -f1)\"
+test \"\$before_nonimage\" = \"\$after_nonimage\"
 docker pull 'ghcr.io/wolverin0/clawtrol:$REVISION'
 test \"\$(docker image inspect 'ghcr.io/wolverin0/clawtrol:$REVISION' \
   --format '{{ index .Config.Labels \"org.opencontainers.image.revision\" }}')\" = '$REVISION'
 docker compose \
   --env-file release.env.next \
-  --env-file \"\$HOME/.config/clawtrol/runtime.env\" \
-  -f docker-compose.yml.next config --quiet"
+  -f docker-compose.yml config --quiet
+test \"\$(docker compose --env-file release.env.next \
+  -f docker-compose.yml config --images)\" = \
+  'ghcr.io/wolverin0/clawtrol:$REVISION'"
 ```
 
 Do not continue if the image label, Compose image, or tested SHA differ.
@@ -96,23 +112,22 @@ migrations wait until the compatibility soak and a separate release.
 
 ## Cut over one web container
 
-Back up the previous non-secret release descriptor, atomically activate the new
-descriptor, and recreate only the web service:
+Back up the canonical environment, atomically activate the candidate, and
+recreate only the web service. The guarded Compose descriptor stays untouched:
 
 ```bash
 ssh "$CLAWTROL_VM" "set -eu
 cd \"\$HOME/.local/share/clawtrol-deploy\"
-test ! -f release.env || cp release.env release.env.previous
-test ! -f docker-compose.yml || cp docker-compose.yml docker-compose.yml.previous
+cp release.env release.env.previous
+chmod 600 release.env.previous
 mv release.env.next release.env
-mv docker-compose.yml.next docker-compose.yml
 docker compose \
   --env-file release.env \
-  --env-file \"\$HOME/.config/clawtrol/runtime.env\" \
+  -f docker-compose.yml \
   pull clawdeck
 docker compose \
   --env-file release.env \
-  --env-file \"\$HOME/.config/clawtrol/runtime.env\" \
+  -f docker-compose.yml \
   up -d --no-build --no-deps clawdeck"
 ```
 

--- a/app/controllers/control_room_controller.rb
+++ b/app/controllers/control_room_controller.rb
@@ -5,19 +5,28 @@ class ControlRoomController < ApplicationController
   QUEUED_STATES = %w[queued ready].freeze
   WAITING_STATES = %w[failed review].freeze
   TERMINAL_STATES = %w[done cancelled].freeze
+  WORKSPACE_LANES = {
+    "waiting" => { title: "Needs you", collection: :waiting_on_you },
+    "running" => { title: "In progress", collection: :running_now },
+    "queued" => { title: "Scheduled", collection: :queued_next },
+    "program" => { title: "Programs", collection: :programs }
+  }.freeze
 
   before_action :set_task, only: %i[thread message approve retry cancel]
   helper_method :intent_result_summary, :pane_display_status, :orchestration_items,
-    :task_needs_attention?
+    :task_needs_attention?, :workspace_lanes, :active_lane
 
   def show
     @full_width_page = true
     load_control_room_state
     @selected_task = selected_task
+    @active_lane = selected_lane(@selected_task)
   end
 
   def live
     load_control_room_state
+    @selected_task = selected_task
+    @active_lane = selected_lane(@selected_task)
     render partial: "live_payload"
   end
 
@@ -43,7 +52,7 @@ class ControlRoomController < ApplicationController
       record
     end
 
-    redirect_to control_room_path(task_id: @task.id),
+    redirect_to control_room_path(task_id: @task.id, lane: params[:lane]),
       notice: "Message queued as intent ##{intent.id}."
   rescue Orchestration::InvalidRequest => e
     redirect_to control_room_path(task_id: @task.id), alert: e.message
@@ -53,7 +62,7 @@ class ControlRoomController < ApplicationController
     define_method(action) do
       source = source_for_task!(@task)
       intent = create_intent(source, action.to_s, @task, {})
-      redirect_to control_room_path(task_id: @task.id),
+      redirect_to control_room_path(task_id: @task.id, lane: params[:lane]),
         notice: "#{action.to_s.titleize} queued as intent ##{intent.id}."
     rescue Orchestration::InvalidRequest => e
       redirect_to control_room_path(task_id: @task.id), alert: e.message
@@ -127,7 +136,7 @@ class ControlRoomController < ApplicationController
     @queued_next = grouped.fetch(:queued, [])
     @programs = grouped.fetch(:program, [])
     @unclassified_tasks = grouped.fetch(:unclassified, [])
-    @recent = grouped.fetch(:recent, []).first(25)
+    @recent = grouped.fetch(:recent, [])
     @project_work_counts = project_work_counts
   end
 
@@ -169,6 +178,33 @@ class ControlRoomController < ApplicationController
     return if params[:task_id].blank?
 
     @tasks.find { |task| task.id == params[:task_id].to_i }
+  end
+
+  def workspace_lanes
+    WORKSPACE_LANES.transform_values do |definition|
+      definition.merge(tasks: instance_variable_get(:"@#{definition[:collection]}"))
+    end
+  end
+
+  def active_lane
+    @active_lane || "waiting"
+  end
+
+  def selected_lane(task)
+    requested = params[:lane].to_s
+    return requested if WORKSPACE_LANES.key?(requested)
+    return lane_key(task_lane(task)) if task
+
+    WORKSPACE_LANES.keys.find { |key| workspace_lanes.dig(key, :tasks)&.any? } || "waiting"
+  end
+
+  def lane_key(lane)
+    {
+      waiting: "waiting",
+      running: "running",
+      queued: "queued",
+      program: "program"
+    }.fetch(lane, "waiting")
   end
 
   def create_task_intent(kind:, default_project: nil)

--- a/app/views/control_room/_fleet.html.erb
+++ b/app/views/control_room/_fleet.html.erb
@@ -1,12 +1,12 @@
 <% panes = Array(@source&.panes) %>
 <% status_counts = panes.map { |pane| pane_display_status(pane) }.tally %>
-<details class="group rounded-xl border border-border bg-bg-surface"
+<details class="group shrink-0 border-b border-border bg-bg-base/35"
          data-control-room-live-region="fleet"
          data-source-count="<%= panes.length %>"
          data-rendered-count="<%= panes.length %>">
-  <summary class="flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 px-4 py-3">
-    <div class="flex flex-wrap items-center gap-3">
-      <span class="text-sm font-semibold text-content">Fleet · <%= panes.length %> panes</span>
+  <summary class="flex min-h-11 cursor-pointer list-none flex-wrap items-center gap-x-4 gap-y-2 px-4 py-2 lg:px-5">
+    <span class="text-xs font-semibold uppercase tracking-[0.14em] text-content-muted">Fleet · <%= panes.length %> panes</span>
+    <div class="flex flex-1 flex-wrap items-center gap-3">
       <% {
            "working" => ["bg-green-400", "text-green-300"],
            "waiting" => ["bg-yellow-400", "text-yellow-200"],
@@ -17,26 +17,17 @@
          }.each do |status, classes| %>
         <% count = status_counts.fetch(status, 0) %>
         <% next unless count.positive? %>
-        <span class="inline-flex items-center gap-1.5 text-xs <%= classes.last %>">
-          <span class="size-2 rounded-full <%= classes.first %> <%= "animate-pulse" if status == "working" %>"></span>
+        <span class="inline-flex items-center gap-1.5 text-xs font-medium <%= classes.last %>">
+          <span class="size-2 rounded-full <%= classes.first %> <%= "animate-pulse" if status == "working" %>" aria-hidden="true"></span>
           <%= count %> <%= status %>
         </span>
       <% end %>
     </div>
-    <span class="text-xs text-content-muted">
-      <% if @source&.last_seen_at %>
-        <% a2a_updates = @source.health.to_h.dig("fleet", "a2a_envelopes").to_i %>
-        synced <%= time_ago_in_words(@source.last_seen_at) %> ago ·
-        <%= a2a_updates.positive? ? "#{a2a_updates} A2A updates in latest sync" : "No A2A updates in latest sync" %> ·
-        expand pane details
-      <% else %>
-        no bridge telemetry · expand
-      <% end %>
-    </span>
+    <span class="text-xs text-content-muted">Pane details</span>
   </summary>
 
   <% if panes.any? %>
-    <div class="grid max-h-64 gap-2 overflow-y-auto border-t border-border p-3 sm:grid-cols-2 xl:grid-cols-4">
+    <div class="grid max-h-52 gap-2 overflow-y-auto border-t border-border p-3 sm:grid-cols-2 xl:grid-cols-4">
       <% panes.each do |pane| %>
         <% status = pane_display_status(pane) %>
         <% status_style = case status
@@ -50,20 +41,15 @@
                  data-pane-status="<%= status %>"
                  aria-label="pane <%= pane["pane_id"] || pane["id"] %>, <%= pane["project"] %>, <%= status %>">
           <div class="flex items-center justify-between gap-2">
-            <span class="font-semibold text-content">pane <%= pane["pane_id"] || pane["id"] %> · <%= pane["project"] %></span>
-            <span class="inline-flex items-center gap-1">
-              <span class="size-2 rounded-full bg-current <%= "animate-pulse" if status == "working" %>"></span>
+            <span class="truncate font-semibold text-content">pane <%= pane["pane_id"] || pane["id"] %> · <%= pane["project"] %></span>
+            <span class="inline-flex shrink-0 items-center gap-1">
+              <span class="size-2 rounded-full bg-current <%= "animate-pulse" if status == "working" %>" aria-hidden="true"></span>
               <%= status %>
             </span>
           </div>
           <% if pane["title"].present? || pane["model"].present? || pane["ctx"].present? %>
             <p class="mt-1 truncate text-[11px] text-content-muted">
               <%= [pane["title"], pane["persona"], pane["model"], pane["ctx"]].compact_blank.join(" · ") %>
-            </p>
-          <% end %>
-          <% if pane["session_pct"].present? || pane["weekly_pct"].present? %>
-            <p class="mt-1 text-[11px] text-content-muted">
-              Session <%= pane["session_pct"].presence || "—" %>% · week <%= pane["weekly_pct"].presence || "—" %>%
             </p>
           <% end %>
         </article>

--- a/app/views/control_room/_live_payload.html.erb
+++ b/app/views/control_room/_live_payload.html.erb
@@ -1,4 +1,4 @@
 <%= render "source_health" %>
 <%= render "fleet" %>
-<%= render "request_status" %>
 <%= render "task_board" %>
+<%= render "selected_task_summary" if @selected_task %>

--- a/app/views/control_room/_request_status.html.erb
+++ b/app/views/control_room/_request_status.html.erb
@@ -1,38 +1,29 @@
-<details class="rounded-xl border border-border bg-bg-surface"
-         data-control-room-live-region="requests"
+<details data-control-room-live-region="requests"
          data-source-count="<%= @recent_intents.size %>"
          data-rendered-count="<%= @recent_intents.size %>">
-  <summary class="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3">
-    <div>
-      <span class="text-sm font-semibold text-content">Delivery log</span>
-      <span class="ml-2 text-xs text-content-muted">Receipts only · expand</span>
-    </div>
+  <summary class="flex min-h-11 cursor-pointer list-none items-center justify-between px-4 py-2 text-xs font-semibold text-content">
+    Delivery receipts
     <% if @pending_intents.any? %>
-      <span class="rounded-full bg-accent/15 px-2 py-1 text-xs font-semibold text-accent">
-        <%= pluralize(@pending_intents.size, "pending") %>
-      </span>
+      <span class="rounded-md bg-accent/15 px-2 py-0.5 text-accent"><%= @pending_intents.size %> pending</span>
     <% else %>
-      <span class="text-xs text-content-muted"><%= @recent_intents.size %> recent</span>
+      <span class="font-normal text-content-muted"><%= @recent_intents.size %></span>
     <% end %>
   </summary>
-
-  <% if @recent_intents.any? %>
-    <div class="grid max-h-64 gap-2 overflow-y-auto border-t border-border p-3 md:grid-cols-2 xl:grid-cols-3">
-      <% @recent_intents.each do |intent| %>
-        <% tone = { "applied" => "border-green-400/25 text-green-400", "rejected" => "border-red-400/25 text-red-400" }.fetch(intent.status, "border-accent/25 text-accent") %>
-        <div class="rounded-lg border bg-bg-elevated px-3 py-2 <%= tone %>">
-          <div class="flex items-center justify-between gap-3 text-xs">
-            <span class="font-semibold">#<%= intent.id %> <%= intent.kind.humanize %></span>
-            <span><%= intent.status.humanize %></span>
-          </div>
-          <p class="mt-1 text-xs text-content-muted">
-            <%= intent_result_summary(intent) || (intent.status == "pending" ? "Waiting for Wezbridge" : "Processed by Wezbridge") %>
-            · <%= time_ago_in_words(intent.processed_at || intent.created_at) %> ago
-          </p>
+  <div class="max-h-44 space-y-1 overflow-y-auto border-t border-border p-2">
+    <% @recent_intents.each do |intent| %>
+      <% tone = { "applied" => "text-green-400", "rejected" => "text-red-400" }.fetch(intent.status, "text-accent") %>
+      <div class="rounded-md bg-bg-elevated px-2 py-2 text-xs">
+        <div class="flex items-center justify-between gap-2">
+          <strong class="<%= tone %>">#<%= intent.id %> <%= intent.kind.humanize %></strong>
+          <span class="text-content-muted"><%= intent.status.humanize %></span>
         </div>
-      <% end %>
-    </div>
-  <% else %>
-    <p class="border-t border-border p-4 text-sm text-content-muted">No requests have been sent yet.</p>
-  <% end %>
+        <p class="mt-1 truncate text-content-muted">
+          <%= intent_result_summary(intent) || (intent.status == "pending" ? "Waiting for Wezbridge" : "Processed by Wezbridge") %>
+        </p>
+      </div>
+    <% end %>
+    <% if @recent_intents.empty? %>
+      <p class="px-2 py-3 text-content-muted">No requests have been sent yet.</p>
+    <% end %>
+  </div>
 </details>

--- a/app/views/control_room/_selected_task_summary.html.erb
+++ b/app/views/control_room/_selected_task_summary.html.erb
@@ -1,0 +1,47 @@
+<% state = @selected_task.state_data.fetch("orchestration", {}) %>
+<% contract = state["contract"].to_h %>
+<% gate = contract["gate"].presence || contract["kind"].presence %>
+<% latest_reply = @selected_task.agent_messages.reject { |message| message.metadata["provenance"] == "operator" }.max_by(&:created_at) %>
+<div class="min-h-0 flex-1 overflow-y-auto px-5 py-4"
+     data-control-room-live-region="selected-task-summary">
+  <dl class="grid gap-3 sm:grid-cols-2">
+    <div class="rounded-lg border border-border bg-bg-elevated p-3">
+      <dt class="text-[11px] font-semibold uppercase tracking-wider text-content-muted">Blocked by</dt>
+      <dd class="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-content-secondary">
+        <%= state["blocker"].presence || "No blocker was supplied." %>
+      </dd>
+      <% if gate %>
+        <span class="mt-3 inline-flex rounded-md border border-yellow-500/30 bg-yellow-500/10 px-2 py-1 text-xs font-semibold text-yellow-200">
+          Gate · <%= gate %>
+        </span>
+      <% end %>
+    </div>
+    <div class="rounded-lg border border-border bg-bg-elevated p-3">
+      <dt class="text-[11px] font-semibold uppercase tracking-wider text-content-muted">Next action</dt>
+      <dd class="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-content-secondary">
+        <%= state["next_action"].presence || "Reply with your direction, or open the full task for complete context." %>
+      </dd>
+    </div>
+  </dl>
+
+  <section class="mt-4">
+    <div class="flex items-center justify-between gap-3">
+      <h3 class="text-xs font-semibold uppercase tracking-wider text-content-muted">Latest from pane 0</h3>
+      <span class="text-xs text-content-muted">Full history lives in the task panel</span>
+    </div>
+    <% if latest_reply %>
+      <article class="mt-2 rounded-lg border border-border bg-bg-elevated p-4">
+        <div class="flex items-center justify-between gap-3 text-xs">
+          <strong class="text-content"><%= latest_reply.display_sender %></strong>
+          <time class="text-content-muted"
+                datetime="<%= latest_reply.created_at.iso8601 %>"><%= time_ago_in_words(latest_reply.created_at) %> ago</time>
+        </div>
+        <p class="mt-2 line-clamp-6 whitespace-pre-wrap text-sm leading-relaxed text-content-secondary"><%= latest_reply.content %></p>
+      </article>
+    <% else %>
+      <div class="mt-2 rounded-lg border border-dashed border-border px-4 py-5 text-sm text-content-muted">
+        Pane 0 has not replied in this task yet.
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/control_room/_source_health.html.erb
+++ b/app/views/control_room/_source_health.html.erb
@@ -4,38 +4,33 @@
 <% last_error = @source&.last_error.presence %>
 <% warning = stale || last_error.present? %>
 <section data-control-room-live-region="source-health"
-         class="rounded-xl border px-4 py-3 <%= warning ? "border-red-400/40 bg-red-400/10" : "border-green-400/25 bg-green-400/5" %>"
+         class="flex min-h-11 flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border px-3 py-2 <%= warning ? "border-red-400/40 bg-red-400/10" : "border-green-400/25 bg-green-400/5" %>"
          role="<%= warning ? "alert" : "status" %>">
-  <div class="flex flex-wrap items-center justify-between gap-2 text-xs">
-    <div class="flex flex-wrap items-center gap-2">
-      <% if @source %>
-        <span class="font-semibold <%= warning ? "text-red-300" : "text-green-400" %>">
-          <%= @source.profile %> · <%= warning ? "attention" : @source.display_status %>
-        </span>
-        <span class="text-content-muted">
-          bridge <%= @source.last_seen_at ? "synced #{time_ago_in_words(@source.last_seen_at)} ago" : "has not synced yet" %>
-        </span>
-      <% else %>
-        <span class="font-semibold text-yellow-300">Waiting for the Wezbridge bridge</span>
-      <% end %>
-    </div>
-    <span class="<%= warning ? "text-yellow-300" : "text-green-400" %>"
-          data-control-room-live-target="status"
-          aria-live="polite">Page refresh connecting…</span>
-  </div>
+  <% if @source %>
+    <span class="inline-flex items-center gap-2 font-semibold <%= warning ? "text-red-300" : "text-green-400" %>">
+      <span class="size-2 rounded-full bg-current" aria-hidden="true"></span>
+      <%= warning ? "Bridge needs attention" : "Fleet healthy" %>
+    </span>
+    <span class="text-xs text-content-muted">
+      <%= @source.last_seen_at ? "synced #{time_ago_in_words(@source.last_seen_at)} ago" : "not synced yet" %>
+    </span>
+  <% else %>
+    <span class="font-semibold text-yellow-300">Waiting for Wezbridge</span>
+  <% end %>
+  <span class="sr-only"
+        data-control-room-live-target="status"
+        aria-live="polite">Page refresh connecting…</span>
   <% if warning %>
-    <p class="mt-2 text-xs text-red-200">
-      This board may be showing old state.
+    <span class="basis-full text-xs text-red-200">
+      State may be stale.
       <% if health["stale_seconds"].present? %>
         No progress for <%= distance_of_time_in_words(health["stale_seconds"].to_i) %>.
       <% elsif @source&.last_seen_at %>
         Last sync was <%= time_ago_in_words(@source.last_seen_at) %> ago.
-      <% else %>
-        No successful sync has been recorded.
       <% end %>
       <% if last_error %>
-        <span class="font-semibold">Bridge error:</span> <%= last_error %>
+        <strong>Bridge error:</strong> <%= last_error %>
       <% end %>
-    </p>
+    </span>
   <% end %>
 </section>

--- a/app/views/control_room/_task_board.html.erb
+++ b/app/views/control_room/_task_board.html.erb
@@ -1,100 +1,116 @@
-<section class="space-y-4"
+<section class="flex min-h-0 flex-1 flex-col"
          data-control-room-live-region="task-board"
          data-open-source-count="<%= @waiting_on_you.length + @running_now.length + @queued_next.length + @programs.length + @unclassified_tasks.length %>"
          data-unclassified-count="<%= @unclassified_tasks.length %>">
-  <div class="rounded-xl border border-border bg-bg-surface p-4"
-       data-board-section="project-work-summary"
-       data-source-count="<%= @project_work_counts.length %>"
-       data-rendered-count="<%= @project_work_counts.length %>">
-    <div class="flex flex-wrap items-baseline justify-between gap-2">
-      <div>
-        <h2 class="text-sm font-semibold text-content">Work by project</h2>
-        <p class="mt-1 text-xs text-content-muted">Counts describe the actual lane, not a generic “active” state.</p>
-      </div>
-      <p class="text-xs text-content-muted">
-        <%= @waiting_on_you.length + @running_now.length + @queued_next.length + @programs.length + @unclassified_tasks.length %> open source rows ·
-        <%= @unclassified_tasks.length %> unclassified
-      </p>
-    </div>
-    <div class="mt-3 flex flex-wrap gap-2">
-      <% @project_work_counts.each do |project, counts| %>
-        <% details = counts.filter_map { |lane, count| "#{count} #{lane}" if count.positive? } %>
-        <span class="rounded-lg border border-border bg-bg-elevated px-3 py-2 text-xs text-content">
-          <strong><%= project %></strong>: <%= details.join(" · ") %>
-        </span>
-      <% end %>
-      <% if @project_work_counts.empty? %>
-        <p class="text-xs text-content-muted">No open work is mirrored.</p>
+  <nav class="shrink-0 border-b border-border px-3 pt-2" aria-label="Work status">
+    <div class="grid grid-cols-2 gap-1 sm:grid-cols-4">
+      <% workspace_lanes.each do |key, lane| %>
+        <% active = key == active_lane %>
+        <%= link_to control_room_path(lane: key),
+              class: "flex min-h-11 items-center justify-center gap-2 border-b-2 px-2 py-2 text-sm font-semibold transition-colors #{active ? "border-accent text-content" : "border-transparent text-content-muted hover:border-border hover:text-content"}",
+              aria: { current: active ? "page" : nil },
+              data: { workspace_lane: key } do %>
+          <span><%= lane[:title] %></span>
+          <span class="min-w-6 rounded-md px-1.5 py-0.5 text-center text-xs tabular-nums <%= active ? "bg-accent/15 text-accent" : "bg-bg-elevated text-content-muted" %>">
+            <%= lane[:tasks].length %>
+          </span>
+        <% end %>
       <% end %>
     </div>
-  </div>
+  </nav>
 
   <% if @unclassified_tasks.any? %>
-    <details class="rounded-xl border border-yellow-500/40 bg-yellow-500/10 p-4"
+    <details class="shrink-0 border-b border-yellow-500/35 bg-yellow-500/10 px-4 py-2"
              data-board-section="unclassified"
              data-source-count="<%= @unclassified_tasks.length %>"
              data-rendered-count="<%= [@unclassified_tasks.length, 20].min %>">
-      <summary class="cursor-pointer text-sm font-semibold text-yellow-200">
-        <%= pluralize(@unclassified_tasks.length, "task") %> could not be classified · show
+      <summary class="cursor-pointer text-xs font-semibold text-yellow-200">
+        <%= pluralize(@unclassified_tasks.length, "task") %> could not be classified · inspect
       </summary>
-      <p class="mt-2 text-xs text-yellow-100/80">
-        This is a cockpit classification gap, not work you owe. The tasks remain visible here until their source state is understood.
-      </p>
-      <div class="mt-3 grid gap-2 md:grid-cols-2">
+      <p class="mt-2 text-xs text-yellow-100/80">This is a cockpit classification gap, not work you owe.</p>
+      <div class="mt-2 space-y-1">
         <% @unclassified_tasks.first(20).each do |task| %>
           <% state = task.state_data.fetch("orchestration", {}) %>
-          <%= link_to control_room_path(task_id: task.id),
-                class: "rounded-lg border border-yellow-500/30 bg-bg-elevated p-3 text-sm text-content hover:border-yellow-400/60",
+          <%= link_to control_room_path(task_id: task.id, lane: active_lane),
+                class: "block rounded-md border border-yellow-500/25 bg-bg-elevated px-3 py-2 text-xs text-content",
                 data: { task_origin_id: task.origin_session_id } do %>
-            <span class="font-medium"><%= task.name %></span>
-            <span class="mt-1 block text-xs text-content-muted">
-              <%= state["project"] %> · source state “<%= state["source_state"].presence || "missing" %>”
-            </span>
+            <strong><%= task.name %></strong>
+            <span class="ml-2 text-content-muted"><%= state["project"] %> · “<%= state["source_state"].presence || "missing" %>”</span>
           <% end %>
         <% end %>
       </div>
     </details>
   <% end %>
 
-  <div class="grid gap-4 md:grid-cols-2 2xl:grid-cols-4">
-    <%= render "task_list",
-          title: "Waiting on You",
-          description: "Decisions, replies, reviews, and retries that genuinely need you.",
-          empty_message: "Nothing needs your input.",
-          tasks: @waiting_on_you,
-          show_action: true %>
-    <%= render "task_list",
-          title: "Running Now",
-          description: "Work with an active executor right now.",
-          empty_message: "No executor is running a task.",
-          tasks: @running_now,
-          show_action: false %>
-    <%= render "task_list",
-          title: "Queued Next",
-          description: "Accepted work waiting for an executor.",
-          empty_message: "Nothing is waiting to start.",
-          tasks: @queued_next,
-          show_action: false %>
-    <%= render "task_list",
-          title: "Programs",
-          description: "Long-running coordination and oversight.",
-          empty_message: "No ongoing programs.",
-          tasks: @programs,
-          show_action: false %>
+  <div class="min-h-0 flex-1 overflow-hidden">
+    <% workspace_lanes.each do |key, lane| %>
+      <%= render "task_list",
+            title: lane[:title],
+            tasks: lane[:tasks],
+            lane: key,
+            active: key == active_lane %>
+    <% end %>
   </div>
 
-  <details class="rounded-xl border border-border bg-bg-surface">
-    <summary class="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-content">
-      Recently completed · <%= @recent.length %>
-      <span class="ml-2 text-xs font-normal text-content-muted">history · expand</span>
-    </summary>
-    <div class="border-t border-border p-3">
-      <%= render "task_list",
-            title: "Recently Completed",
-            description: "Finished and cancelled work, kept for reference.",
-            empty_message: "No recent completed work.",
-            tasks: @recent,
-            show_action: false %>
+  <footer class="shrink-0 border-t border-border bg-bg-base/35">
+    <div class="flex min-h-11 flex-wrap items-center justify-between gap-2 px-4 py-2 text-xs text-content-muted">
+      <span>
+        <strong class="text-content"><%= @waiting_on_you.length + @running_now.length + @queued_next.length + @programs.length + @unclassified_tasks.length %></strong>
+        open items · <strong class="<%= @unclassified_tasks.any? ? "text-yellow-300" : "text-green-400" %>"><%= @unclassified_tasks.length %></strong> unclassified
+      </span>
+      <div class="flex items-center gap-3">
+        <span><%= @recent.length %> completed</span>
+        <span><%= @recent_intents.length %> receipts</span>
+      </div>
     </div>
-  </details>
+
+    <div class="grid border-t border-border sm:grid-cols-3">
+      <details class="border-b border-border sm:border-b-0 sm:border-r">
+        <summary class="flex min-h-11 cursor-pointer list-none items-center justify-between px-4 py-2 text-xs font-semibold text-content">
+          Work by project <span class="font-normal text-content-muted"><%= @project_work_counts.length %></span>
+        </summary>
+        <div class="max-h-44 overflow-y-auto border-t border-border p-3"
+             data-board-section="project-work-summary"
+             data-source-count="<%= @project_work_counts.length %>"
+             data-rendered-count="<%= @project_work_counts.length %>">
+          <div class="flex flex-wrap gap-2">
+            <% @project_work_counts.each do |project, counts| %>
+              <% details = counts.filter_map { |lane_name, count| "#{count} #{lane_name}" if count.positive? } %>
+              <span class="rounded-md border border-border bg-bg-elevated px-2 py-1 text-xs text-content">
+                <strong><%= project %></strong>: <%= details.join(" · ") %>
+              </span>
+            <% end %>
+            <% if @project_work_counts.empty? %>
+              <span class="text-content-muted">No open work is mirrored.</span>
+            <% end %>
+          </div>
+        </div>
+      </details>
+
+      <details class="border-b border-border sm:border-b-0 sm:border-r"
+               data-board-section="recently-completed"
+               data-source-count="<%= @recent.length %>"
+               data-rendered-count="<%= [@recent.length, 20].min %>">
+        <summary class="flex min-h-11 cursor-pointer list-none items-center justify-between px-4 py-2 text-xs font-semibold text-content">
+          Recently completed <span class="font-normal text-content-muted"><%= @recent.length > 20 ? "20 of #{@recent.length}" : @recent.length %></span>
+        </summary>
+        <div class="max-h-44 space-y-1 overflow-y-auto border-t border-border p-2">
+          <% @recent.first(20).each do |task| %>
+            <% state = task.state_data.fetch("orchestration", {}) %>
+            <%= link_to control_room_path(task_id: task.id, lane: active_lane),
+                  class: "flex items-center justify-between gap-2 rounded-md px-2 py-2 text-xs text-content-secondary hover:bg-bg-elevated",
+                  data: { task_origin_id: task.origin_session_id } do %>
+              <span class="truncate"><%= task.name %></span>
+              <span class="shrink-0 text-content-muted"><%= state["source_state"] %></span>
+            <% end %>
+          <% end %>
+          <% if @recent.empty? %>
+            <p class="px-2 py-3 text-content-muted">No completed work yet.</p>
+          <% end %>
+        </div>
+      </details>
+
+      <%= render "request_status" %>
+    </div>
+  </footer>
 </section>

--- a/app/views/control_room/_task_list.html.erb
+++ b/app/views/control_room/_task_list.html.erb
@@ -1,35 +1,54 @@
-<section class="min-h-40 rounded-xl border border-border bg-bg-surface p-4"
+<section class="h-full min-h-0 <%= "hidden" unless active %>"
          data-board-section="<%= title.parameterize %>"
          data-source-count="<%= tasks.length %>"
-         data-rendered-count="<%= [tasks.length, 20].min %>">
-  <div class="flex items-center justify-between gap-2">
-    <div>
-      <h2 class="text-sm font-semibold text-content"><%= title %></h2>
-      <p class="mt-1 text-xs text-content-muted"><%= description %></p>
-    </div>
-    <span class="rounded-full bg-bg-elevated px-2 py-0.5 text-xs text-content-muted">
-      <%= tasks.length > 20 ? "#{[tasks.length, 20].min} of #{tasks.length}" : tasks.length %>
-    </span>
+         data-rendered-count="<%= [tasks.length, 50].min %>"
+         data-workspace-panel="<%= lane %>">
+  <div class="grid grid-cols-[minmax(0,1fr)_7rem_4.5rem] gap-3 border-b border-border bg-bg-base/20 px-4 py-2 text-[11px] font-semibold uppercase tracking-wider text-content-muted">
+    <span>Project · work</span>
+    <span>Status</span>
+    <span class="text-right">Updated</span>
   </div>
-  <div class="mt-3 max-h-[22rem] space-y-2 overflow-y-auto pr-1">
-    <% tasks.first(20).each do |task| %>
+  <div class="h-[calc(100%-2.25rem)] overflow-y-auto">
+    <% tasks.first(50).each do |task| %>
       <% state = task.state_data.fetch("orchestration", {}) %>
-      <%= link_to control_room_path(task_id: task.id),
-            class: "block rounded-lg border border-border bg-bg-elevated p-3 transition-colors hover:border-accent/40",
+      <% selected = @selected_task&.id == task.id %>
+      <% tone = case lane
+           when "waiting" then "text-yellow-300"
+           when "running" then "text-green-300"
+           when "queued" then "text-sky-300"
+           else "text-violet-300"
+           end %>
+      <%= link_to control_room_path(task_id: task.id, lane: lane),
+            class: "grid min-h-[4.5rem] grid-cols-[minmax(0,1fr)_7rem_4.5rem] items-center gap-3 border-b border-border px-4 py-3 transition-colors hover:bg-bg-elevated/70 #{selected ? "bg-accent/10 shadow-[inset_3px_0_0_var(--color-accent)]" : ""}",
+            aria: { current: selected ? "true" : nil },
             data: { task_origin_id: task.origin_session_id } do %>
-        <p class="text-sm font-medium text-content"><%= task.name %></p>
-        <div class="mt-1 flex items-center justify-between gap-2 text-xs text-content-muted">
-          <span class="truncate"><%= state["project"] %></span>
-          <span><%= state["source_state"] %></span>
-        </div>
-        <%= render "task_context", state:, compact: true %>
-        <% if show_action %>
-          <p class="mt-3 text-xs font-semibold text-accent">Open and answer</p>
-        <% end %>
+        <span class="min-w-0">
+          <span class="block truncate text-xs font-semibold uppercase tracking-wide text-accent"><%= state["project"].presence || "Unassigned" %></span>
+          <span class="mt-1 block truncate text-sm font-medium text-content"><%= task.name %></span>
+          <% if lane == "waiting" && state["blocker"].present? %>
+            <span class="mt-1 block truncate text-xs text-content-muted"><%= state["blocker"] %></span>
+          <% end %>
+        </span>
+        <span class="inline-flex items-center gap-2 text-xs font-semibold uppercase <%= tone %>">
+          <span class="size-2 rounded-full bg-current <%= "animate-pulse" if lane == "running" %>" aria-hidden="true"></span>
+          <%= { "waiting" => "Needs you", "running" => "Working", "queued" => "Scheduled", "program" => "Program" }.fetch(lane) %>
+        </span>
+        <time class="text-right text-xs tabular-nums text-content-muted"
+              datetime="<%= task.updated_at.iso8601 %>"><%= time_ago_in_words(task.updated_at) %></time>
       <% end %>
     <% end %>
     <% if tasks.empty? %>
-      <p class="py-4 text-center text-xs text-content-muted"><%= empty_message %></p>
+      <div class="flex h-full min-h-56 flex-col items-center justify-center px-6 text-center">
+        <span class="flex size-12 items-center justify-center rounded-full border border-border bg-bg-elevated text-content-muted">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="size-5" stroke="currentColor" stroke-width="1.8">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m5 12 4 4L19 6"/>
+          </svg>
+        </span>
+        <p class="mt-3 font-semibold text-content">
+          <%= { "waiting" => "Nothing needs you", "running" => "No work is running", "queued" => "Nothing is scheduled", "program" => "No programs are active" }.fetch(lane) %>
+        </p>
+        <p class="mt-1 text-xs text-content-muted">The count above is sourced directly from the mirrored ledger.</p>
+      </div>
     <% end %>
   </div>
 </section>

--- a/app/views/control_room/show.html.erb
+++ b/app/views/control_room/show.html.erb
@@ -1,162 +1,157 @@
 <% content_for :title, "Control Room" %>
 <% content_for :breadcrumb_standalone, "Control Room" %>
-<div class="space-y-4 py-4 <%= "xl:pr-[33rem]" if @selected_task %>"
+<div class="py-3 lg:h-[calc(100dvh-4.5rem)]"
      data-controller="control-room-live"
-     data-control-room-live-url-value="<%= control_room_live_path(source_id: @source&.id) %>"
+     data-control-room-live-url-value="<%= control_room_live_path(source_id: @source&.id, task_id: @selected_task&.id, lane: active_lane) %>"
      data-control-room-live-interval-value="5000">
-  <header class="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
-    <div>
-      <p class="text-xs font-semibold uppercase tracking-[0.2em] text-accent">Personal orchestration</p>
-      <h1 class="mt-1 text-3xl font-semibold text-content font-display">Control Room</h1>
-    </div>
-    <p class="max-w-xl text-sm text-content-muted lg:text-right">
-      See what needs you, what is running, and what pane 0 reported—without watching every terminal.
-    </p>
-  </header>
-
-  <%= render "source_health" %>
-  <%= render "fleet" %>
-  <%= render "task_board" %>
-
-  <section class="grid items-start gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(22rem,1fr)]">
-    <div class="rounded-xl border border-accent/30 bg-bg-surface p-5 shadow-[0_0_0_1px_rgba(255,78,85,0.05)]">
-      <div class="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.18em] text-accent">Primary action</p>
-          <h2 class="mt-1 text-lg font-semibold text-content">Talk to pane 0</h2>
-          <p class="mt-1 text-xs text-content-muted">
-            Ask about one project or the whole fleet. The answer arrives in the task drawer.
-          </p>
+  <div class="flex h-full min-h-[42rem] flex-col overflow-hidden rounded-xl border border-border bg-bg-surface">
+    <header class="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3 lg:px-5">
+      <div class="flex min-w-0 items-center gap-3">
+        <div class="flex size-10 shrink-0 items-center justify-center rounded-lg border border-accent/35 bg-accent/10 text-accent">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="size-5" stroke="currentColor" stroke-width="1.8">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 7.5 12 3l8 4.5v9L12 21l-8-4.5v-9Z"/>
+            <path stroke-linecap="round" stroke-linejoin="round" d="m8 10 4-2.25L16 10v4l-4 2.25L8 14v-4Z"/>
+          </svg>
         </div>
-        <span class="rounded-full bg-accent/10 px-2 py-1 text-xs text-accent">Creates a question thread</span>
+        <div class="min-w-0">
+          <h1 class="truncate text-xl font-semibold text-content font-display">Control Room</h1>
+          <p class="truncate text-xs text-content-muted">One place to decide, reply, and see what moves next.</p>
+        </div>
       </div>
-      <%= form_with url: control_room_ask_path, class: "mt-4 grid gap-3 lg:grid-cols-[minmax(12rem,18rem)_minmax(0,1fr)_auto]" do |form| %>
-        <%= form.hidden_field :source_id, value: @source&.id, id: "question_source_id" %>
-        <div>
-          <%= form.label :project, "Question context", for: "question_project", class: "mb-1 block text-xs font-medium text-content-secondary" %>
-          <%= form.select :project, @question_options, { include_blank: false },
-                id: "question_project",
-                class: "w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-        </div>
-        <div>
-          <%= form.label :title, "Question title", for: "question_title", class: "mb-1 block text-xs font-medium text-content-secondary" %>
-          <%= form.text_field :title, id: "question_title", placeholder: "What is this about?",
-                class: "w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-        </div>
-        <%= form.submit "Ask pane 0", disabled: @source.blank?,
-              class: "mt-5 cursor-pointer self-start rounded-lg bg-accent px-4 py-2 font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40" %>
-        <div class="lg:col-span-3">
-          <%= form.label :brief, "Question", for: "question_brief", class: "sr-only" %>
-          <%= form.text_area :brief, id: "question_brief", required: true, rows: 3,
-                placeholder: "What do you want pane 0 to assess, explain, or decide?",
-                class: "w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-        </div>
-      <% end %>
-    </div>
+      <%= render "source_health" %>
+    </header>
 
-    <div class="space-y-3">
-      <details class="rounded-xl border border-border bg-bg-surface">
-        <summary class="cursor-pointer list-none px-4 py-3">
-          <span class="text-sm font-semibold text-content">Create work</span>
-          <span class="ml-2 text-xs text-content-muted">secondary action · expand</span>
-        </summary>
-        <div class="border-t border-border p-4">
-          <p class="text-xs text-content-muted">Record validated work in the durable ledger for pane 0 to dispatch.</p>
-          <%= form_with url: control_room_tasks_path, class: "mt-3 grid gap-3" do |form| %>
-            <%= form.hidden_field :source_id, value: @source&.id, id: "task_source_id" %>
-            <%= form.label :project, "Work context", for: "task_project", class: "sr-only" %>
-            <%= form.select :project, @project_options, { prompt: "Choose a live pane / project" },
-                  id: "task_project",
-                  required: true,
-                  class: "w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-            <%= form.label :title, "Task title", for: "task_title", class: "sr-only" %>
-            <%= form.text_field :title, id: "task_title", placeholder: "Task title",
-                  class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-            <%= form.label :brief, "Task brief", for: "task_brief", class: "sr-only" %>
-            <%= form.text_area :brief, id: "task_brief", required: true, rows: 3, placeholder: "What should be done?",
-                  class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-            <%= form.label :acceptance, "Acceptance criteria", for: "task_acceptance", class: "sr-only" %>
-            <%= form.text_area :acceptance, id: "task_acceptance", rows: 2, placeholder: "What does done look like?",
-                  class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-            <div class="flex items-center justify-between gap-3">
-              <%= form.label :priority, "Priority", for: "task_priority", class: "sr-only" %>
-              <%= form.select :priority, [["Normal", "normal"], ["High", "high"], ["Low", "low"]], {},
-                    id: "task_priority",
-                    class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-              <%= form.submit "Create task", disabled: @source.blank?,
-                    class: "cursor-pointer rounded-lg bg-accent px-4 py-2 font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40" %>
+    <%= render "fleet" %>
+
+    <div class="grid min-h-0 flex-1 lg:grid-cols-[minmax(32rem,1.08fr)_minmax(28rem,0.92fr)]">
+      <main class="flex min-h-[32rem] flex-col border-b border-border lg:min-h-0 lg:border-b-0 lg:border-r">
+        <%= render "task_board" %>
+      </main>
+
+      <aside id="task-thread"
+             class="flex min-h-[34rem] flex-col bg-bg-base/30"
+             role="complementary"
+             data-persistent-drawer="true"
+             aria-labelledby="task-thread-title">
+        <% if @selected_task %>
+          <% state = @selected_task.state_data.fetch("orchestration", {}) %>
+          <header class="shrink-0 border-b border-border px-5 py-4">
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0">
+                <p class="text-xs font-semibold uppercase tracking-[0.14em] text-accent"><%= state["project"] %></p>
+                <h2 id="task-thread-title" class="mt-1 text-xl font-semibold leading-tight text-content">
+                  <%= @selected_task.name %>
+                </h2>
+              </div>
+              <%= link_to control_room_path(lane: active_lane),
+                    class: "flex size-11 shrink-0 items-center justify-center rounded-lg border border-border text-content-muted transition-colors hover:border-accent/40 hover:text-content",
+                    aria: { label: "Close task detail" } do %>
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="size-5" stroke="currentColor" stroke-width="1.8">
+                  <path stroke-linecap="round" d="m7 7 10 10M17 7 7 17"/>
+                </svg>
+              <% end %>
             </div>
-          <% end %>
-        </div>
-      </details>
+          </header>
 
-      <%= render "request_status" %>
+          <%= render "selected_task_summary" %>
+
+          <div class="shrink-0 border-t border-border bg-bg-surface px-5 py-4">
+            <%= form_with url: control_room_task_messages_path(@selected_task),
+                  class: "space-y-3" do |form| %>
+              <%= form.hidden_field :lane, value: active_lane %>
+              <%= form.label :content, "Reply to pane 0", class: "block text-xs font-semibold text-content-secondary" %>
+              <%= form.text_area :content, required: true, rows: 3, placeholder: "Type your direction or answer…",
+                    class: "w-full resize-none rounded-lg border border-border bg-bg-elevated px-3 py-3 text-base text-content placeholder:text-content-muted focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" %>
+              <%= form.submit "Reply", class: "min-h-11 cursor-pointer rounded-lg bg-accent px-5 py-2.5 font-semibold text-white transition-colors hover:bg-accent-hover" %>
+            <% end %>
+            <div class="mt-3 flex flex-wrap items-center gap-2">
+              <% if task_needs_attention?(@selected_task) || state["source_state"] == "review" %>
+                <%= button_to "Approve", approve_control_room_task_path(@selected_task),
+                      params: { lane: active_lane },
+                      class: "min-h-11 rounded-lg border border-green-500/40 px-4 py-2.5 font-semibold text-green-300 hover:bg-green-500/10" %>
+              <% end %>
+              <% if state["source_state"] == "failed" %>
+                <%= button_to "Retry", retry_control_room_task_path(@selected_task),
+                      params: { lane: active_lane },
+                      class: "min-h-11 rounded-lg border border-sky-500/40 px-4 py-2.5 font-semibold text-sky-300 hover:bg-sky-500/10" %>
+              <% end %>
+              <%= link_to "Open full task", board_task_path(@selected_task.board, @selected_task),
+                    data: { turbo_frame: "task_panel" },
+                    class: "inline-flex min-h-11 items-center rounded-lg border border-border px-4 py-2.5 font-semibold text-content-secondary hover:border-accent/40 hover:text-content" %>
+              <% unless %w[done cancelled].include?(state["source_state"]) %>
+                <%= button_to "Cancel", cancel_control_room_task_path(@selected_task),
+                      params: { lane: active_lane },
+                      class: "ml-auto min-h-11 rounded-lg px-3 py-2.5 font-semibold text-red-400 hover:bg-red-500/10" %>
+              <% end %>
+            </div>
+          </div>
+        <% else %>
+          <header class="shrink-0 border-b border-border px-5 py-4">
+            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-accent">Orchestrator</p>
+            <h2 id="task-thread-title" class="mt-1 text-xl font-semibold text-content">Ask pane 0</h2>
+            <p class="mt-1 text-sm text-content-muted">Ask about one project or request a fleet-wide assessment.</p>
+          </header>
+
+          <div class="min-h-0 flex-1 overflow-y-auto p-5">
+            <%= form_with url: control_room_ask_path, class: "space-y-4" do |form| %>
+              <%= form.hidden_field :source_id, value: @source&.id, id: "question_source_id" %>
+              <div>
+                <%= form.label :project, "Question context", for: "question_project", class: "mb-1.5 block text-xs font-medium text-content-secondary" %>
+                <%= form.select :project, @question_options, { include_blank: false },
+                      id: "question_project",
+                      class: "min-h-11 w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+              </div>
+              <div>
+                <%= form.label :title, "Question title", for: "question_title", class: "mb-1.5 block text-xs font-medium text-content-secondary" %>
+                <%= form.text_field :title, id: "question_title", placeholder: "What is this about?",
+                      class: "min-h-11 w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+              </div>
+              <div>
+                <%= form.label :brief, "Question", for: "question_brief", class: "mb-1.5 block text-xs font-medium text-content-secondary" %>
+                <%= form.text_area :brief, id: "question_brief", required: true, rows: 6,
+                      placeholder: "What do you want pane 0 to assess, explain, or decide?",
+                      class: "w-full resize-none rounded-lg border border-border bg-bg-elevated px-3 py-3 text-base text-content" %>
+              </div>
+              <%= form.submit "Ask pane 0", disabled: @source.blank?,
+                    class: "min-h-11 w-full cursor-pointer rounded-lg bg-accent px-4 py-2.5 font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40" %>
+            <% end %>
+
+            <details class="mt-5 rounded-lg border border-border bg-bg-surface">
+              <summary class="flex min-h-11 cursor-pointer list-none items-center justify-between px-4 py-3">
+                <span class="font-semibold text-content">Create new work</span>
+                <span class="text-xs text-content-muted">expand</span>
+              </summary>
+              <div class="border-t border-border p-4">
+                <%= form_with url: control_room_tasks_path, class: "grid gap-3" do |form| %>
+                  <%= form.hidden_field :source_id, value: @source&.id, id: "task_source_id" %>
+                  <%= form.label :project, "Work context", for: "task_project", class: "sr-only" %>
+                  <%= form.select :project, @project_options, { prompt: "Choose a live pane / project" },
+                        id: "task_project", required: true,
+                        class: "min-h-11 w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+                  <%= form.label :title, "Task title", for: "task_title", class: "sr-only" %>
+                  <%= form.text_field :title, id: "task_title", placeholder: "Task title",
+                        class: "min-h-11 rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+                  <%= form.label :brief, "Task brief", for: "task_brief", class: "sr-only" %>
+                  <%= form.text_area :brief, id: "task_brief", required: true, rows: 3, placeholder: "What should be done?",
+                        class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+                  <%= form.label :acceptance, "Acceptance criteria", for: "task_acceptance", class: "sr-only" %>
+                  <%= form.text_area :acceptance, id: "task_acceptance", rows: 2, placeholder: "What does done look like?",
+                        class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+                  <div class="flex items-center justify-between gap-3">
+                    <%= form.label :priority, "Priority", for: "task_priority", class: "sr-only" %>
+                    <%= form.select :priority, [["Normal", "normal"], ["High", "high"], ["Low", "low"]], {},
+                          id: "task_priority",
+                          class: "min-h-11 rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+                    <%= form.submit "Create task", disabled: @source.blank?,
+                          class: "min-h-11 cursor-pointer rounded-lg bg-accent px-4 py-2 font-semibold text-white disabled:opacity-40" %>
+                  </div>
+                <% end %>
+              </div>
+            </details>
+          </div>
+        <% end %>
+      </aside>
     </div>
-  </section>
-
-  <% if @selected_task %>
-    <% state = @selected_task.state_data.fetch("orchestration", {}) %>
-    <%# Cockpit boundary: quick decisions only. Rich task detail belongs exclusively to the existing Boards task panel. %>
-    <aside id="task-thread"
-           class="fixed inset-y-0 right-0 z-50 flex w-full max-w-lg flex-col border-l border-border bg-bg-surface shadow-2xl"
-           role="complementary"
-           data-persistent-drawer="true"
-           aria-labelledby="task-thread-title">
-      <header class="shrink-0 border-b border-border p-4">
-        <div class="flex items-start justify-between gap-3">
-          <div class="min-w-0">
-            <p class="text-xs uppercase tracking-wider text-content-muted"><%= state["project"] %> · <%= state["source_state"] %></p>
-            <h2 id="task-thread-title" class="mt-1 text-lg font-semibold text-content"><%= @selected_task.name %></h2>
-          </div>
-          <div class="flex shrink-0 gap-2">
-            <%= link_to "Open full task", board_task_path(@selected_task.board, @selected_task),
-                  data: { turbo_frame: "task_panel" },
-                  class: "rounded-lg bg-accent px-3 py-2 text-xs font-semibold text-white" %>
-            <%= link_to "Close", control_room_path(source_id: @source&.id),
-                  class: "rounded-lg border border-border px-3 py-2 text-xs font-semibold text-content-secondary hover:border-accent/40" %>
-          </div>
-        </div>
-        <div class="mt-3 flex flex-wrap items-center justify-end gap-2">
-          <div class="flex flex-wrap gap-2">
-            <% if task_needs_attention?(@selected_task) || state["source_state"] == "review" %>
-              <%= button_to "Approve", approve_control_room_task_path(@selected_task), class: "rounded-lg bg-green-600 px-3 py-2 text-xs font-semibold text-white" %>
-            <% end %>
-            <% if state["source_state"] == "failed" %>
-              <%= button_to "Retry", retry_control_room_task_path(@selected_task), class: "rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white" %>
-            <% end %>
-            <% unless %w[done cancelled].include?(state["source_state"]) %>
-              <%= button_to "Cancel", cancel_control_room_task_path(@selected_task), class: "rounded-lg border border-red-500/40 px-3 py-2 text-xs font-semibold text-red-400" %>
-            <% end %>
-          </div>
-        </div>
-      </header>
-
-      <div class="min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
-        <section class="rounded-lg border border-border bg-bg-elevated p-3">
-          <h3 class="text-xs font-semibold uppercase tracking-wider text-content-muted">Why you are needed</h3>
-          <p class="mt-2 whitespace-pre-wrap text-sm text-content-secondary">
-            <%= state["blocker"].presence || "No blocker detail was supplied. Use Open full task for the complete record." %>
-          </p>
-        </section>
-        <section class="rounded-lg border border-border bg-bg-elevated p-3">
-          <h3 class="text-xs font-semibold uppercase tracking-wider text-content-muted">Next action</h3>
-          <p class="mt-2 whitespace-pre-wrap text-sm text-content-secondary">
-            <%= state["next_action"].presence || "Reply with your direction, or open the full task for more context." %>
-          </p>
-        </section>
-        <p class="text-xs text-content-muted">
-          This quick drawer intentionally excludes artifacts, diffs, dependencies, run history, and agent output.
-        </p>
-      </div>
-
-      <%= form_with url: control_room_task_messages_path(@selected_task),
-            class: "flex shrink-0 gap-3 border-t border-border bg-bg-surface p-4" do |form| %>
-        <%= form.label :content, "Reply", class: "sr-only" %>
-        <%= form.text_area :content, required: true, rows: 2, placeholder: "Reply to pane 0…",
-              class: "min-w-0 flex-1 rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-        <%= form.submit "Send", class: "cursor-pointer self-end rounded-lg bg-accent px-4 py-2 font-semibold text-white" %>
-      <% end %>
-    </aside>
-  <% end %>
+  </div>
   <%= turbo_frame_tag "task_panel" %>
 </div>

--- a/test/controllers/control_room_controller_test.rb
+++ b/test/controllers/control_room_controller_test.rb
@@ -76,16 +76,8 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     assert_select "main#main-content.w-full.max-w-none"
     assert_select "[data-controller='control-room-live']", count: 1
     assert_select "[data-control-room-live-region='requests']", count: 1
-    assert_select "summary", text: /Delivery log/
+    assert_select "summary", text: /Delivery receipts/
     assert_select "[data-controller='gateway-health']", count: 0
-    assert_select "select#task_project", count: 1
-    assert_select "select#question_project", count: 1
-    assert_select "select#question_project" do |select|
-      assert_equal "_fleet", select.first.css("option").first["value"]
-    end
-    assert_select "option[value='whatsappbot']", text: /pane 5/, count: 2
-    assert_select "option[value='omniremote']", text: /present/, count: 2
-    assert_includes response.body, "No A2A updates in latest sync"
     assert_includes response.body, "Projected task"
     assert_select "[data-control-room-live-region='fleet'][data-source-count='3'][data-rendered-count='3']"
     assert_select "[data-pane-status='working']", count: 1
@@ -99,9 +91,18 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     assert_select "#task-thread [data-task-context='full']", count: 0
     assert_select "#task-thread #task-thread-messages", count: 0
     projected_link = css_select("[data-task-origin-id='#{task.origin_session_id}']").sole
-    assert_not_includes projected_link["href"], "#task-thread"
+    assert_includes projected_link["href"], "task_id=#{task.id}"
     ids = css_select("[id]").map { |element| element["id"] }
     assert_equal ids.uniq, ids, "Control Room must not render duplicate HTML ids"
+
+    get control_room_path
+    assert_select "select#task_project", count: 1
+    assert_select "select#question_project", count: 1
+    assert_select "select#question_project" do |select|
+      assert_equal "_fleet", select.first.css("option").first["value"]
+    end
+    assert_select "option[value='whatsappbot']", text: /pane 5/, count: 2
+    assert_select "option[value='omniremote']", text: /present/, count: 2
 
     other = Task.create!(user: users(:two), board: boards(:two), name: "Other",
       origin_session_key: "wezbridge:primary:task:T-OTHER")
@@ -172,30 +173,20 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     get control_room_path(task_id: blocked.id)
 
     assert_response :success
-    attention = css_select("[data-board-section='waiting-on-you']").sole
+    attention = css_select("[data-board-section='needs-you']").sole
     assert_equal "3", attention["data-source-count"]
     assert_equal "3", attention["data-rendered-count"]
     assert_equal 1, attention.css("[data-task-origin-id='#{blocked.origin_session_id}']").count
     assert_equal 1, attention.css("[data-task-origin-id='#{decision.origin_session_id}']").count
     assert_equal 1, attention.css("[data-task-origin-id='#{question.origin_session_id}']").count
     assert_equal 0, attention.css("[data-task-origin-id='T-0025']").count
-    assert_includes attention.text, "Blocked by"
     assert_includes attention.text, "ARS 8,025,812.27"
-    assert_includes attention.text, "Gate"
-    assert_includes attention.text, "operator"
-    assert_includes attention.text, "Next action"
-    assert_includes attention.text, "Acceptance"
-    assert_includes attention.text, "Evidence"
-    blocked_card = attention.css("[data-task-origin-id='#{blocked.origin_session_id}']").sole
-    assert_includes blocked_card.text, "1 criterion"
-    assert_includes blocked_card.text, "1 evidence item"
-    assert_not_includes blocked_card.text, "Decision is recorded"
-    assert_not_includes blocked_card.text, "20 balances affect current members"
-    assert_equal 3, blocked_card.css("[data-task-context='compact'] .line-clamp-2").count
 
     assert_select "#task-thread [data-task-context='full']", count: 0
-    assert_select "#task-thread", text: /Operator must decide whether to dispose ARS 8,025,812\.27/
-    assert_select "#task-thread", text: /Answer with approve or retain/
+    summary = css_select("[data-control-room-live-region='selected-task-summary']").sole
+    assert_includes summary.text, "Operator must decide whether to dispose ARS 8,025,812.27"
+    assert_includes summary.text, "Gate · operator"
+    assert_includes summary.text, "Answer with approve or retain"
     assert_not_includes css_select("#task-thread").sole.text, "Decision is recorded"
     assert_not_includes css_select("#task-thread").sole.text, "20 balances affect current members"
     assert_select "#task-thread form[action='#{control_room_task_messages_path(blocked)}']", count: 1
@@ -236,9 +227,9 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     expected = {
-      "waiting-on-you" => [waiting],
-      "running-now" => [running],
-      "queued-next" => [queued],
+      "needs-you" => [waiting],
+      "in-progress" => [running],
+      "scheduled" => [queued],
       "programs" => [program, explicit_program],
       "unclassified" => [unclassified],
       "recently-completed" => [completed]
@@ -279,9 +270,9 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "[data-control-room-live-region='source-health'][role='alert']", count: 1 do
-      assert_select "span", text: /primary · attention/
-      assert_select "p", text: /board may be showing old state/i
-      assert_select "p", text: /sync HTTP 503/
+      assert_select "span", text: /Bridge needs attention/
+      assert_select "span", text: /State may be stale/i
+      assert_select "span", text: /sync HTTP 503/
     end
   end
 
@@ -310,6 +301,28 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
       origin_session_key: "wezbridge:primary:task:T-OTHER")
     get control_room_task_thread_path(other)
     assert_response :not_found
+  end
+
+  test "renders a focus inbox with persistent detail and latest pane reply" do
+    task = projected_task
+    task.agent_messages.create!(
+      direction: "incoming",
+      message_type: "output",
+      content: "The canary passed and awaits your ruling.",
+      sender_name: "pane 0"
+    )
+    sign_in_as(@user)
+
+    get control_room_path(task_id: task.id)
+
+    assert_response :success
+    assert_select "nav[aria-label='Work status'] [aria-current='page']", text: /Needs you/
+    assert_select "[data-workspace-panel='waiting']:not(.hidden)", count: 1
+    assert_select "[data-workspace-panel='running'].hidden", count: 1
+    assert_select "aside#task-thread[data-persistent-drawer='true']", count: 1
+    assert_select "[data-control-room-live-region='selected-task-summary']", text: /The canary passed/
+    assert_select "#task-thread textarea[placeholder='Type your direction or answer…']", count: 1
+    assert_select "#task-thread a", text: "Open full task", count: 1
   end
 
   private

--- a/test/system/control_room_test.rb
+++ b/test/system/control_room_test.rb
@@ -36,17 +36,14 @@ class ControlRoomTest < ApplicationSystemTestCase
   end
 
   test "creates work and sends a task-scoped message from the cockpit" do
-    visit control_room_path(task_id: @task.id)
+    visit control_room_path
 
     assert_text "Control Room"
     assert_text "pane 0"
-    within("[data-board-section='waiting-on-you']") do
+    within("[data-board-section='needs-you']") do
       assert_text "Operator ruling required before execution."
-      assert_text(/gate/i)
-      assert_text "operator"
     end
-    assert_selector "#task-thread[role='complementary'][data-persistent-drawer='true']"
-    find("summary", text: "Create work").click
+    find("summary", text: "Create new work").click
     within("form[action='#{control_room_tasks_path}']") do
       select "pane 0 — wezbridge (idle)", from: "Work context"
       fill_in "title", with: "Ship a focused fix"
@@ -56,9 +53,11 @@ class ControlRoomTest < ApplicationSystemTestCase
 
     assert_text "Task queued as intent"
     visit control_room_path(task_id: @task.id)
+    assert_selector "#task-thread[role='complementary'][data-persistent-drawer='true']"
+    assert_text "Gate · operator"
     within("#task-thread") do
       fill_in "content", with: "Please show the exact test evidence."
-      click_button "Send"
+      click_button "Reply"
     end
 
     assert_text "Message queued as intent"
@@ -86,13 +85,20 @@ class ControlRoomTest < ApplicationSystemTestCase
 
     within("#task-thread") { click_link "Open full task" }
 
-    assert_selector "[data-controller~='task-modal']", wait: 8
-    assert_text "Review the canary"
+    if ApplicationSystemTestCase::CHROME_AVAILABLE
+      assert_selector "[data-controller~='task-modal']", wait: 8
+      assert_text "Review the canary"
+    else
+      assert_current_path board_task_path(@task.board, @task)
+      assert_text "Confirm the live evidence."
+    end
   end
 
   test "refreshes cockpit state without clearing a draft" do
+    skip "Requires JavaScript support" unless ApplicationSystemTestCase::CHROME_AVAILABLE
+
     visit control_room_path
-    find("summary", text: "Create work").click
+    find("summary", text: "Create new work").click
     fill_in "Task title", with: "Keep this draft"
 
     @user.tasks.create!(
@@ -114,5 +120,32 @@ class ControlRoomTest < ApplicationSystemTestCase
     assert_text "Appeared without a reload", wait: 8
     assert_field "Task title", with: "Keep this draft"
     assert_text "Live cockpit · updated just now"
+  end
+
+  test "switches work lanes and keeps the selected detail beside the list" do
+    @user.tasks.create!(
+      board: boards(:one),
+      name: "Running live verification",
+      description: "Observe the live release.",
+      origin_session_id: "T-0002",
+      origin_session_key: "wezbridge:primary:task:T-0002",
+      status: :in_progress,
+      state_data: {
+        "orchestration" => {
+          "profile" => "primary",
+          "source_state" => "running",
+          "project" => "clawtrol"
+        }
+      }
+    )
+
+    visit control_room_path
+    click_link "In progress"
+
+    assert_selector "[data-workspace-panel='running']:not(.hidden)"
+    click_link "Running live verification"
+    assert_selector "#task-thread[data-persistent-drawer='true']"
+    assert_text "Running live verification"
+    assert_selector "[data-workspace-panel='running']:not(.hidden)"
   end
 end

--- a/test/system/control_room_test.rb
+++ b/test/system/control_room_test.rb
@@ -117,7 +117,8 @@ class ControlRoomTest < ApplicationSystemTestCase
       }
     )
 
-    assert_text "Appeared without a reload", wait: 8
+    assert_selector "[data-workspace-panel='running']",
+      text: "Appeared without a reload", visible: :all, wait: 8
     assert_field "Task title", with: "Keep this draft"
     assert_text "Live cockpit · updated just now"
   end


### PR DESCRIPTION
## What changed
- replace the stacked Control Room dashboard with the selected focus-inbox split workspace
- surface compact fleet health, disjoint work lanes, and a persistent non-modal decision/reply pane
- keep source-vs-rendered counts and unclassified work explicit
- correct the deploy skill so it refuses the retired runtime.env and preserves the canonical VM release environment

## Product boundary
The right pane is only for blocker, next action, latest Pane 0 reply, reply, approve/retry/cancel, and Open full task. It must never absorb diffs, artifacts, dependencies, run history, or full agent output; those remain owned by the existing Boards task panel.

## Verification
- focused controller: 11 runs, 122 assertions, 0 failures
- focused system: 5 runs, 23 assertions, 0 failures, 1 JavaScript skip in the earlier isolated check
- RuboCop touched Ruby/test files: no offenses
- production asset build: passed
- full release gate runs in hosted CI; live human verification follows exact-SHA VM deployment

No schema or auth changes.