### PR TITLE
feat: simplify Control Room cockpit

### DIFF
--- a/app/controllers/control_room_controller.rb
+++ b/app/controllers/control_room_controller.rb
@@ -3,18 +3,39 @@
 class ControlRoomController < ApplicationController
   PROGRAM_KINDS = %w[bot-fix qa-oversight].freeze
   QUEUED_STATES = %w[queued ready].freeze
-  WAITING_STATES = %w[failed review].freeze
+  PARKED_STATES = %w[blocked failed paused].freeze
   TERMINAL_STATES = %w[done cancelled].freeze
   WORKSPACE_LANES = {
-    "waiting" => { title: "Needs you", collection: :waiting_on_you },
-    "running" => { title: "In progress", collection: :running_now },
-    "queued" => { title: "Scheduled", collection: :queued_next },
-    "program" => { title: "Programs", collection: :programs }
+    "waiting" => {
+      title: "Needs you",
+      description: "Only explicit decisions and reviews",
+      section: "needs-you",
+      collection: :waiting_on_you
+    },
+    "running" => {
+      title: "Running now",
+      description: "Ledger tasks executing now",
+      section: "running-now",
+      collection: :running_now
+    },
+    "queued" => {
+      title: "Queue",
+      description: "Ready or waiting to start — not time-scheduled",
+      section: "queue",
+      collection: :queued_next
+    },
+    "parked" => {
+      title: "Paused",
+      description: "Blocked or failed; no decision requested",
+      section: "paused",
+      collection: :parked
+    }
   }.freeze
 
   before_action :set_task, only: %i[thread message approve retry cancel]
   helper_method :intent_result_summary, :pane_display_status, :orchestration_items,
-    :task_needs_attention?, :workspace_lanes, :active_lane
+    :task_needs_attention?, :workspace_lanes, :active_lane, :program_task?,
+    :source_state, :stale_blocker?, :task_lane, :lane_key
 
   def show
     @full_width_page = true
@@ -105,7 +126,7 @@ class ControlRoomController < ApplicationController
 
   def pane_display_status(pane)
     status = (pane["status"] || pane["state"]).to_s
-    status.blank? || status == "unknown" ? "present" : status
+    status.blank? || %w[unknown present].include?(status) ? "not-reporting" : status
   end
 
   def orchestration_items(value)
@@ -116,10 +137,10 @@ class ControlRoomController < ApplicationController
 
   def task_needs_attention?(task)
     state = task.state_data.fetch("orchestration", {})
-    task[:blocked] || # Mirrored FSM blocker; blocked? only checks dependency rows.
-      task.blocked? ||
+    operator_gate?(state) ||
       task[:needs_decision] || # Canonical decision flag; the enum value is a legacy fallback.
       task.status == "needs_decision" ||
+      state["source_state"] == "review" ||
       (state["kind"] == "question" && !%w[done cancelled].include?(state["source_state"]))
   end
 
@@ -134,18 +155,21 @@ class ControlRoomController < ApplicationController
     @waiting_on_you = grouped.fetch(:waiting, [])
     @running_now = grouped.fetch(:running, [])
     @queued_next = grouped.fetch(:queued, [])
-    @programs = grouped.fetch(:program, [])
+    @parked = grouped.fetch(:parked, [])
     @unclassified_tasks = grouped.fetch(:unclassified, [])
     @recent = grouped.fetch(:recent, [])
+    @programs = @tasks.reject { |task| TERMINAL_STATES.include?(source_state(task)) }
+      .select { |task| program_task?(task) }
     @project_work_counts = project_work_counts
   end
 
   def task_lane(task)
     return :recent if TERMINAL_STATES.include?(source_state(task))
-    return :program if program_task?(task)
-    return :waiting if task_needs_attention?(task) || WAITING_STATES.include?(source_state(task))
+    return :parked if stale_blocker?(task)
+    return :waiting if task_needs_attention?(task)
     return :running if source_state(task) == "running"
-    return :queued if QUEUED_STATES.include?(source_state(task))
+    return :queued if QUEUED_STATES.include?(source_state(task)) && task_blocker(task).blank?
+    return :parked if PARKED_STATES.include?(source_state(task)) || task_blocker(task).present?
 
     :unclassified
   end
@@ -160,13 +184,15 @@ class ControlRoomController < ApplicationController
       waiting: @waiting_on_you,
       running: @running_now,
       queued: @queued_next,
-      program: @programs,
+      parked: @parked,
       unclassified: @unclassified_tasks
     }
     projects = lanes.values.flatten.filter_map { |task| task_project(task) }.uniq.sort
 
     projects.to_h do |project|
-      [project, lanes.transform_values { |tasks| tasks.count { |task| task_project(task) == project } }]
+      counts = lanes.transform_values { |tasks| tasks.count { |task| task_project(task) == project } }
+      counts[:programs] = @programs.count { |task| task_project(task) == project }
+      [project, counts]
     end
   end
 
@@ -203,8 +229,27 @@ class ControlRoomController < ApplicationController
       waiting: "waiting",
       running: "running",
       queued: "queued",
-      program: "program"
+      parked: "parked"
     }.fetch(lane, "waiting")
+  end
+
+  def operator_gate?(state)
+    contract = state["contract"].to_h
+    contract["gate"] == "operator" || contract["mode"] == "born_blocked"
+  end
+
+  def task_blocker(task)
+    task.state_data.dig("orchestration", "blocker").to_s
+  end
+
+  def stale_blocker?(task)
+    references = task_blocker(task).scan(/\bT-\d+\b/).uniq
+    return false if references.empty?
+
+    terminal_ids = @tasks.filter_map do |candidate|
+      candidate.origin_session_id if TERMINAL_STATES.include?(source_state(candidate))
+    end
+    references.all? { |reference| terminal_ids.include?(reference) }
   end
 
   def create_task_intent(kind:, default_project: nil)

--- a/app/views/control_room/_activity_distinction.html.erb
+++ b/app/views/control_room/_activity_distinction.html.erb
@@ -1,0 +1,7 @@
+<% busy_panes = Array(@source&.panes).count { |pane| pane_display_status(pane) == "working" } %>
+<p class="mt-2 px-1 text-xs text-content-muted"
+   data-control-room-live-region="activity-distinction">
+  <strong class="text-content"><%= @running_now.length %></strong> ledger <%= "task".pluralize(@running_now.length) %> running
+  <span aria-hidden="true">·</span>
+  <strong class="text-content"><%= busy_panes %></strong> <%= "pane".pluralize(busy_panes) %> busy with conversation, checks, or unledgered work
+</p>

--- a/app/views/control_room/_composer_bar.html.erb
+++ b/app/views/control_room/_composer_bar.html.erb
@@ -1,0 +1,87 @@
+<section class="shrink-0 border-b border-border bg-bg-base/25 px-3 py-2 lg:px-4">
+  <div class="grid gap-2 sm:grid-cols-2">
+    <details class="group rounded-lg border border-border bg-bg-surface sm:open:col-span-2">
+      <summary class="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 px-3 py-2">
+        <span class="flex items-center gap-2 font-semibold text-content">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="size-4 text-accent" stroke="currentColor" stroke-width="1.8">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M7 8h10M7 12h7m-9 8 2.3-3.4A8 8 0 1 1 20 10a8 8 0 0 1-8 8H8.5L5 20Z"/>
+          </svg>
+          Ask pane 0
+        </span>
+        <span class="text-xs text-content-muted">one action away</span>
+      </summary>
+      <div class="border-t border-border p-3">
+        <%= form_with url: control_room_ask_path, class: "grid gap-3 lg:grid-cols-[minmax(12rem,0.75fr)_minmax(12rem,0.8fr)_minmax(20rem,1.8fr)_auto]" do |form| %>
+          <%= form.hidden_field :source_id, value: @source&.id, id: "question_source_id" %>
+          <div>
+            <%= form.label :project, "Context", for: "question_project", class: "mb-1 block text-xs font-medium text-content-secondary" %>
+            <%= form.select :project, @question_options, { include_blank: false },
+                  id: "question_project",
+                  class: "min-h-11 w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+          </div>
+          <div>
+            <%= form.label :title, "Subject", for: "question_title", class: "mb-1 block text-xs font-medium text-content-secondary" %>
+            <%= form.text_field :title, id: "question_title", placeholder: "What is this about?",
+                  class: "min-h-11 w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+          </div>
+          <div>
+            <%= form.label :brief, "Question", for: "question_brief", class: "mb-1 block text-xs font-medium text-content-secondary" %>
+            <%= form.text_area :brief, id: "question_brief", required: true, rows: 2,
+                  placeholder: "What should pane 0 assess, explain, or decide?",
+                  class: "min-h-11 w-full resize-none rounded-lg border border-border bg-bg-elevated px-3 py-2 text-base text-content" %>
+          </div>
+          <%= form.submit "Ask", disabled: @source.blank?,
+                class: "mt-5 min-h-11 cursor-pointer rounded-lg bg-accent px-5 py-2.5 font-semibold text-white transition-[transform,background-color] duration-150 active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-40" %>
+        <% end %>
+      </div>
+    </details>
+
+    <details class="group rounded-lg border border-border bg-bg-surface sm:open:col-span-2">
+      <summary class="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 px-3 py-2">
+        <span class="flex items-center gap-2 font-semibold text-content">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="size-4 text-accent" stroke="currentColor" stroke-width="1.8">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14M5 12h14"/>
+          </svg>
+          Create work
+        </span>
+        <span class="text-xs text-content-muted">send to a live project</span>
+      </summary>
+      <div class="border-t border-border p-3">
+        <%= form_with url: control_room_tasks_path,
+              class: "grid gap-3 lg:grid-cols-[minmax(12rem,0.8fr)_minmax(12rem,0.9fr)_minmax(18rem,1.4fr)_minmax(14rem,1fr)_auto]" do |form| %>
+          <%= form.hidden_field :source_id, value: @source&.id, id: "task_source_id" %>
+          <div>
+            <%= form.label :project, "Project", for: "task_project", class: "mb-1 block text-xs font-medium text-content-secondary" %>
+            <%= form.select :project, @project_options, { prompt: "Choose a live project" },
+                  id: "task_project", required: true,
+                  class: "min-h-11 w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+          </div>
+          <div>
+            <%= form.label :title, "Title", for: "task_title", class: "mb-1 block text-xs font-medium text-content-secondary" %>
+            <%= form.text_field :title, id: "task_title", placeholder: "Short task title",
+                  class: "min-h-11 w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+          </div>
+          <div>
+            <%= form.label :brief, "Brief", for: "task_brief", class: "mb-1 block text-xs font-medium text-content-secondary" %>
+            <%= form.text_area :brief, id: "task_brief", required: true, rows: 2, placeholder: "What should be done?",
+                  class: "min-h-11 w-full resize-none rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+          </div>
+          <div>
+            <%= form.label :acceptance, "Done when", for: "task_acceptance", class: "mb-1 block text-xs font-medium text-content-secondary" %>
+            <%= form.text_area :acceptance, id: "task_acceptance", rows: 2, placeholder: "Optional acceptance",
+                  class: "min-h-11 w-full resize-none rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
+          </div>
+          <div class="flex items-end gap-2">
+            <%= form.label :priority, "Priority", for: "task_priority", class: "sr-only" %>
+            <%= form.select :priority, [["Normal", "normal"], ["High", "high"], ["Low", "low"]], {},
+                  id: "task_priority",
+                  class: "min-h-11 rounded-lg border border-border bg-bg-elevated px-2 py-2 text-content" %>
+            <%= form.submit "Create", disabled: @source.blank?,
+                  class: "min-h-11 cursor-pointer rounded-lg bg-accent px-4 py-2 font-semibold text-white transition-transform duration-150 active:scale-[0.97] disabled:opacity-40" %>
+          </div>
+        <% end %>
+      </div>
+    </details>
+  </div>
+  <%= render "activity_distinction" %>
+</section>

--- a/app/views/control_room/_fleet.html.erb
+++ b/app/views/control_room/_fleet.html.erb
@@ -12,14 +12,13 @@
            "waiting" => ["bg-yellow-400", "text-yellow-200"],
            "permission" => ["bg-yellow-400", "text-yellow-200"],
            "idle" => ["bg-sky-400", "text-sky-300"],
-           "present" => ["bg-violet-400", "text-violet-300"],
-           "unknown" => ["bg-slate-400", "text-slate-300"]
+           "not-reporting" => ["bg-slate-400", "text-slate-300"]
          }.each do |status, classes| %>
         <% count = status_counts.fetch(status, 0) %>
         <% next unless count.positive? %>
         <span class="inline-flex items-center gap-1.5 text-xs font-medium <%= classes.last %>">
-          <span class="size-2 rounded-full <%= classes.first %> <%= "animate-pulse" if status == "working" %>" aria-hidden="true"></span>
-          <%= count %> <%= status %>
+          <span class="size-2 rounded-full <%= classes.first %> <%= "animate-pulse motion-reduce:animate-none" if status == "working" %>" aria-hidden="true"></span>
+          <%= count %> <%= status == "not-reporting" ? "not reporting" : status %>
         </span>
       <% end %>
     </div>
@@ -34,7 +33,7 @@
              when "working" then "border-green-400/35 bg-green-400/10 text-green-300"
              when "waiting", "permission" then "border-yellow-400/40 bg-yellow-400/10 text-yellow-200"
              when "idle" then "border-sky-400/30 bg-sky-400/10 text-sky-300"
-             when "present" then "border-violet-400/30 bg-violet-400/10 text-violet-300"
+             when "not-reporting" then "border-slate-400/30 bg-slate-400/10 text-slate-300"
              else "border-border bg-bg-elevated text-content-muted"
              end %>
         <article class="rounded-lg border px-3 py-2 text-xs <%= status_style %>"
@@ -43,8 +42,8 @@
           <div class="flex items-center justify-between gap-2">
             <span class="truncate font-semibold text-content">pane <%= pane["pane_id"] || pane["id"] %> · <%= pane["project"] %></span>
             <span class="inline-flex shrink-0 items-center gap-1">
-              <span class="size-2 rounded-full bg-current <%= "animate-pulse" if status == "working" %>" aria-hidden="true"></span>
-              <%= status %>
+              <span class="size-2 rounded-full bg-current <%= "animate-pulse motion-reduce:animate-none" if status == "working" %>" aria-hidden="true"></span>
+              <%= status == "not-reporting" ? "not reporting" : status %>
             </span>
           </div>
           <% if pane["title"].present? || pane["model"].present? || pane["ctx"].present? %>

--- a/app/views/control_room/_live_payload.html.erb
+++ b/app/views/control_room/_live_payload.html.erb
@@ -1,4 +1,5 @@
 <%= render "source_health" %>
 <%= render "fleet" %>
+<%= render "activity_distinction" %>
 <%= render "task_board" %>
 <%= render "selected_task_summary" if @selected_task %>

--- a/app/views/control_room/_request_status.html.erb
+++ b/app/views/control_room/_request_status.html.erb
@@ -1,7 +1,7 @@
 <details data-control-room-live-region="requests"
          data-source-count="<%= @recent_intents.size %>"
          data-rendered-count="<%= @recent_intents.size %>">
-  <summary class="flex min-h-11 cursor-pointer list-none items-center justify-between px-4 py-2 text-xs font-semibold text-content">
+  <summary class="flex min-h-12 cursor-pointer list-none items-center justify-between px-4 py-2 text-xs font-semibold text-content">
     Delivery receipts
     <% if @pending_intents.any? %>
       <span class="rounded-md bg-accent/15 px-2 py-0.5 text-accent"><%= @pending_intents.size %> pending</span>

--- a/app/views/control_room/_selected_task_drawer.html.erb
+++ b/app/views/control_room/_selected_task_drawer.html.erb
@@ -1,0 +1,85 @@
+<% state = @selected_task.state_data.fetch("orchestration", {}) %>
+<aside id="task-thread"
+       class="flex min-h-[32rem] flex-col border-t border-border bg-bg-base/35 lg:min-h-0 lg:border-l lg:border-t-0"
+       role="complementary"
+       data-persistent-drawer="true"
+       aria-labelledby="task-thread-title">
+  <header class="shrink-0 border-b border-border px-4 py-3">
+    <div class="flex items-start justify-between gap-3">
+      <div class="min-w-0">
+        <div class="flex flex-wrap items-center gap-2">
+          <p class="text-xs font-semibold uppercase tracking-[0.14em] text-accent"><%= state["project"] %></p>
+          <% if program_task?(@selected_task) %>
+            <span class="rounded border border-violet-400/30 bg-violet-400/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-violet-200">
+              Program
+            </span>
+          <% end %>
+          <span class="rounded border border-border bg-bg-elevated px-1.5 py-0.5 text-[10px] font-semibold uppercase text-content-muted">
+            <%= source_state(@selected_task).presence || "unknown" %>
+          </span>
+        </div>
+        <h2 id="task-thread-title" class="mt-1 text-lg font-semibold leading-tight text-content">
+          <%= @selected_task.name %>
+        </h2>
+      </div>
+      <%= link_to control_room_path(lane: active_lane),
+            class: "flex size-11 shrink-0 items-center justify-center rounded-lg border border-border text-content-muted transition-colors hover:border-accent/40 hover:text-content",
+            aria: { label: "Close task detail" } do %>
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="size-5" stroke="currentColor" stroke-width="1.8">
+          <path stroke-linecap="round" d="m7 7 10 10M17 7 7 17"/>
+        </svg>
+      <% end %>
+    </div>
+  </header>
+
+  <%= render "selected_task_summary" %>
+
+  <div class="shrink-0 border-t border-border bg-bg-surface px-4 py-3">
+    <% if task_lane(@selected_task) == :waiting %>
+      <%= form_with url: control_room_task_messages_path(@selected_task), class: "space-y-2" do |form| %>
+        <%= form.hidden_field :lane, value: active_lane %>
+        <%= form.label :content, "Answer pane 0", class: "block text-xs font-semibold text-content-secondary" %>
+        <%= form.text_area :content, required: true, rows: 2, placeholder: "Type your decision or answer…",
+              class: "w-full resize-none rounded-lg border border-border bg-bg-elevated px-3 py-2 text-base text-content placeholder:text-content-muted focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" %>
+        <%= form.submit "Reply",
+              class: "min-h-11 cursor-pointer rounded-lg bg-accent px-5 py-2.5 font-semibold text-white transition-transform duration-150 active:scale-[0.97]" %>
+      <% end %>
+    <% elsif !ControlRoomController::TERMINAL_STATES.include?(source_state(@selected_task)) %>
+      <details class="rounded-lg border border-border bg-bg-base/30">
+        <summary class="flex min-h-11 cursor-pointer list-none items-center justify-between px-3 py-2 text-xs font-semibold text-content-secondary">
+          Send optional direction
+          <span class="font-normal text-content-muted">not required</span>
+        </summary>
+        <%= form_with url: control_room_task_messages_path(@selected_task), class: "space-y-2 border-t border-border p-3" do |form| %>
+          <%= form.hidden_field :lane, value: active_lane %>
+          <%= form.label :content, "Direction for pane 0", class: "block text-xs font-semibold text-content-secondary" %>
+          <%= form.text_area :content, required: true, rows: 2, placeholder: "Add context or change direction…",
+                class: "w-full resize-none rounded-lg border border-border bg-bg-elevated px-3 py-2 text-base text-content placeholder:text-content-muted focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" %>
+          <%= form.submit "Send direction",
+                class: "min-h-11 cursor-pointer rounded-lg bg-accent px-5 py-2.5 font-semibold text-white transition-transform duration-150 active:scale-[0.97]" %>
+        <% end %>
+      </details>
+    <% end %>
+    <div class="mt-2 flex flex-wrap items-center gap-2">
+      <% if task_lane(@selected_task) == :waiting %>
+        <%= button_to "Approve", approve_control_room_task_path(@selected_task),
+              params: { lane: active_lane },
+              class: "min-h-11 rounded-lg border border-green-500/40 px-4 py-2.5 font-semibold text-green-300 hover:bg-green-500/10" %>
+      <% end %>
+      <% if %w[blocked failed].include?(source_state(@selected_task)) || stale_blocker?(@selected_task) %>
+        <%= button_to(source_state(@selected_task) == "failed" ? "Retry" : "Requeue",
+              retry_control_room_task_path(@selected_task),
+              params: { lane: active_lane },
+              class: "min-h-11 rounded-lg border border-sky-500/40 px-4 py-2.5 font-semibold text-sky-300 hover:bg-sky-500/10") %>
+      <% end %>
+      <%= link_to "Open full task", board_task_path(@selected_task.board, @selected_task),
+            data: { turbo_frame: "_top" },
+            class: "inline-flex min-h-11 items-center rounded-lg border border-border px-4 py-2.5 font-semibold text-content-secondary hover:border-accent/40 hover:text-content" %>
+      <% unless ControlRoomController::TERMINAL_STATES.include?(source_state(@selected_task)) %>
+        <%= button_to "Cancel", cancel_control_room_task_path(@selected_task),
+              params: { lane: active_lane },
+              class: "ml-auto min-h-11 rounded-lg px-3 py-2.5 font-semibold text-red-400 hover:bg-red-500/10" %>
+      <% end %>
+    </div>
+  </div>
+</aside>

--- a/app/views/control_room/_selected_task_summary.html.erb
+++ b/app/views/control_room/_selected_task_summary.html.erb
@@ -1,36 +1,55 @@
 <% state = @selected_task.state_data.fetch("orchestration", {}) %>
 <% contract = state["contract"].to_h %>
 <% gate = contract["gate"].presence || contract["kind"].presence %>
+<% lane = task_lane(@selected_task) %>
 <% latest_reply = @selected_task.agent_messages.reject { |message| message.metadata["provenance"] == "operator" }.max_by(&:created_at) %>
-<div class="min-h-0 flex-1 overflow-y-auto px-5 py-4"
+<% status_copy = case lane
+     when :waiting
+       ["Needs your decision", state["blocker"].presence || "Pane 0 needs an explicit decision before this can continue."]
+     when :running
+       ["Working now", "Pane 0 or a worker is actively executing this ledger task."]
+     when :queued
+       ["In the queue", "No response is required. Pane 0 will dispatch it when capacity and priority allow."]
+     when :parked
+       ["Paused", state["blocker"].presence || "This work cannot move until its blocker or failure is resolved."]
+     when :recent
+       ["Finished", "This task is no longer active."]
+     else
+       ["Needs classification", "The mirror did not provide a state the cockpit understands."]
+     end %>
+<div class="min-h-0 flex-1 overflow-y-auto px-4 py-3"
      data-control-room-live-region="selected-task-summary">
-  <dl class="grid gap-3 sm:grid-cols-2">
-    <div class="rounded-lg border border-border bg-bg-elevated p-3">
-      <dt class="text-[11px] font-semibold uppercase tracking-wider text-content-muted">Blocked by</dt>
-      <dd class="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-content-secondary">
-        <%= state["blocker"].presence || "No blocker was supplied." %>
-      </dd>
+  <section class="rounded-lg border border-border bg-bg-elevated p-3">
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <h3 class="text-sm font-semibold text-content"><%= status_copy.first %></h3>
       <% if gate %>
-        <span class="mt-3 inline-flex rounded-md border border-yellow-500/30 bg-yellow-500/10 px-2 py-1 text-xs font-semibold text-yellow-200">
+        <span class="rounded-md border border-yellow-500/30 bg-yellow-500/10 px-2 py-1 text-xs font-semibold text-yellow-200">
           Gate · <%= gate %>
         </span>
       <% end %>
     </div>
-    <div class="rounded-lg border border-border bg-bg-elevated p-3">
-      <dt class="text-[11px] font-semibold uppercase tracking-wider text-content-muted">Next action</dt>
-      <dd class="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-content-secondary">
-        <%= state["next_action"].presence || "Reply with your direction, or open the full task for complete context." %>
-      </dd>
-    </div>
-  </dl>
+    <p class="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-content-secondary"><%= status_copy.last %></p>
+    <% if stale_blocker?(@selected_task) %>
+      <p class="mt-3 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-xs font-medium text-yellow-100">
+        This blocker references completed work. Requeue it or refresh the source record; it does not need a new operator decision.
+      </p>
+    <% end %>
+  </section>
+
+  <% if state["next_action"].present? %>
+    <section class="mt-3 rounded-lg border border-border bg-bg-elevated p-3">
+      <h3 class="text-[11px] font-semibold uppercase tracking-wider text-content-muted">Next action</h3>
+      <p class="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-content-secondary"><%= state["next_action"] %></p>
+    </section>
+  <% end %>
 
   <section class="mt-4">
     <div class="flex items-center justify-between gap-3">
       <h3 class="text-xs font-semibold uppercase tracking-wider text-content-muted">Latest from pane 0</h3>
-      <span class="text-xs text-content-muted">Full history lives in the task panel</span>
+      <span class="text-xs text-content-muted">Full history is in the task page</span>
     </div>
     <% if latest_reply %>
-      <article class="mt-2 rounded-lg border border-border bg-bg-elevated p-4">
+      <article class="mt-2 rounded-lg border border-border bg-bg-elevated p-3">
         <div class="flex items-center justify-between gap-3 text-xs">
           <strong class="text-content"><%= latest_reply.display_sender %></strong>
           <time class="text-content-muted"
@@ -39,7 +58,7 @@
         <p class="mt-2 line-clamp-6 whitespace-pre-wrap text-sm leading-relaxed text-content-secondary"><%= latest_reply.content %></p>
       </article>
     <% else %>
-      <div class="mt-2 rounded-lg border border-dashed border-border px-4 py-5 text-sm text-content-muted">
+      <div class="mt-2 rounded-lg border border-dashed border-border px-3 py-4 text-sm text-content-muted">
         Pane 0 has not replied in this task yet.
       </div>
     <% end %>

--- a/app/views/control_room/_task_board.html.erb
+++ b/app/views/control_room/_task_board.html.erb
@@ -1,23 +1,18 @@
+<% open_count = @waiting_on_you.length + @running_now.length + @queued_next.length + @parked.length + @unclassified_tasks.length %>
 <section class="flex min-h-0 flex-1 flex-col"
          data-control-room-live-region="task-board"
-         data-open-source-count="<%= @waiting_on_you.length + @running_now.length + @queued_next.length + @programs.length + @unclassified_tasks.length %>"
+         data-open-source-count="<%= open_count %>"
          data-unclassified-count="<%= @unclassified_tasks.length %>">
-  <nav class="shrink-0 border-b border-border px-3 pt-2" aria-label="Work status">
-    <div class="grid grid-cols-2 gap-1 sm:grid-cols-4">
-      <% workspace_lanes.each do |key, lane| %>
-        <% active = key == active_lane %>
-        <%= link_to control_room_path(lane: key),
-              class: "flex min-h-11 items-center justify-center gap-2 border-b-2 px-2 py-2 text-sm font-semibold transition-colors #{active ? "border-accent text-content" : "border-transparent text-content-muted hover:border-border hover:text-content"}",
-              aria: { current: active ? "page" : nil },
-              data: { workspace_lane: key } do %>
-          <span><%= lane[:title] %></span>
-          <span class="min-w-6 rounded-md px-1.5 py-0.5 text-center text-xs tabular-nums <%= active ? "bg-accent/15 text-accent" : "bg-bg-elevated text-content-muted" %>">
-            <%= lane[:tasks].length %>
-          </span>
-        <% end %>
-      <% end %>
-    </div>
-  </nav>
+  <header class="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-border bg-bg-base/20 px-4 py-2">
+    <p class="text-xs text-content-muted">
+      <strong class="text-content"><%= open_count %></strong> open
+      <span aria-hidden="true">·</span>
+      <strong class="<%= @unclassified_tasks.any? ? "text-yellow-300" : "text-green-400" %>"><%= @unclassified_tasks.length %></strong> unclassified
+    </p>
+    <p class="text-xs text-content-muted">
+      Programs are an umbrella type; their real state appears below.
+    </p>
+  </header>
 
   <% if @unclassified_tasks.any? %>
     <details class="shrink-0 border-b border-yellow-500/35 bg-yellow-500/10 px-4 py-2"
@@ -42,75 +37,83 @@
     </details>
   <% end %>
 
-  <div class="min-h-0 flex-1 overflow-hidden">
-    <% workspace_lanes.each do |key, lane| %>
-      <%= render "task_list",
-            title: lane[:title],
-            tasks: lane[:tasks],
-            lane: key,
-            active: key == active_lane %>
+  <div class="grid min-h-0 flex-1 gap-2 overflow-y-auto p-2 sm:grid-cols-2 xl:grid-cols-4 xl:overflow-hidden">
+    <% workspace_lanes.each do |key, definition| %>
+      <%= render "task_list", tasks: definition[:tasks], lane: key, definition: definition %>
     <% end %>
   </div>
 
-  <footer class="shrink-0 border-t border-border bg-bg-base/35">
-    <div class="flex min-h-11 flex-wrap items-center justify-between gap-2 px-4 py-2 text-xs text-content-muted">
-      <span>
-        <strong class="text-content"><%= @waiting_on_you.length + @running_now.length + @queued_next.length + @programs.length + @unclassified_tasks.length %></strong>
-        open items · <strong class="<%= @unclassified_tasks.any? ? "text-yellow-300" : "text-green-400" %>"><%= @unclassified_tasks.length %></strong> unclassified
-      </span>
-      <div class="flex items-center gap-3">
-        <span><%= @recent.length %> completed</span>
-        <span><%= @recent_intents.length %> receipts</span>
+  <footer class="grid shrink-0 border-t border-border bg-bg-base/35 sm:grid-cols-2 xl:grid-cols-4">
+    <details class="border-b border-border sm:border-r xl:border-b-0"
+             data-board-section="programs"
+             data-source-count="<%= @programs.length %>"
+             data-rendered-count="<%= [@programs.length, 20].min %>">
+      <summary class="flex min-h-12 cursor-pointer list-none items-center justify-between px-4 py-2 text-xs font-semibold text-content">
+        Programs
+        <span class="font-normal text-content-muted"><%= @programs.length %> umbrella efforts</span>
+      </summary>
+      <div class="max-h-52 space-y-1 overflow-y-auto border-t border-border p-2">
+        <p class="px-2 py-1 text-xs text-content-muted">A program spans multiple tasks. It is not a runtime status.</p>
+        <% @programs.first(20).each do |task| %>
+          <% state = task.state_data.fetch("orchestration", {}) %>
+          <%= link_to control_room_path(task_id: task.id, lane: lane_key(task_lane(task))),
+                class: "flex items-center justify-between gap-2 rounded-md px-2 py-2 text-xs text-content-secondary hover:bg-bg-elevated",
+                data: { task_origin_id: task.origin_session_id } do %>
+            <span class="truncate"><strong class="text-content"><%= state["project"] %></strong> · <%= task.name %></span>
+            <span class="shrink-0 uppercase text-violet-300"><%= source_state(task) %></span>
+          <% end %>
+        <% end %>
+        <% if @programs.empty? %>
+          <p class="px-2 py-3 text-content-muted">No open programs.</p>
+        <% end %>
       </div>
-    </div>
+    </details>
 
-    <div class="grid border-t border-border sm:grid-cols-3">
-      <details class="border-b border-border sm:border-b-0 sm:border-r">
-        <summary class="flex min-h-11 cursor-pointer list-none items-center justify-between px-4 py-2 text-xs font-semibold text-content">
-          Work by project <span class="font-normal text-content-muted"><%= @project_work_counts.length %></span>
-        </summary>
-        <div class="max-h-44 overflow-y-auto border-t border-border p-3"
-             data-board-section="project-work-summary"
-             data-source-count="<%= @project_work_counts.length %>"
-             data-rendered-count="<%= @project_work_counts.length %>">
-          <div class="flex flex-wrap gap-2">
-            <% @project_work_counts.each do |project, counts| %>
-              <% details = counts.filter_map { |lane_name, count| "#{count} #{lane_name}" if count.positive? } %>
-              <span class="rounded-md border border-border bg-bg-elevated px-2 py-1 text-xs text-content">
-                <strong><%= project %></strong>: <%= details.join(" · ") %>
-              </span>
-            <% end %>
-            <% if @project_work_counts.empty? %>
-              <span class="text-content-muted">No open work is mirrored.</span>
-            <% end %>
-          </div>
-        </div>
-      </details>
-
-      <details class="border-b border-border sm:border-b-0 sm:border-r"
-               data-board-section="recently-completed"
-               data-source-count="<%= @recent.length %>"
-               data-rendered-count="<%= [@recent.length, 20].min %>">
-        <summary class="flex min-h-11 cursor-pointer list-none items-center justify-between px-4 py-2 text-xs font-semibold text-content">
-          Recently completed <span class="font-normal text-content-muted"><%= @recent.length > 20 ? "20 of #{@recent.length}" : @recent.length %></span>
-        </summary>
-        <div class="max-h-44 space-y-1 overflow-y-auto border-t border-border p-2">
-          <% @recent.first(20).each do |task| %>
-            <% state = task.state_data.fetch("orchestration", {}) %>
-            <%= link_to control_room_path(task_id: task.id, lane: active_lane),
-                  class: "flex items-center justify-between gap-2 rounded-md px-2 py-2 text-xs text-content-secondary hover:bg-bg-elevated",
-                  data: { task_origin_id: task.origin_session_id } do %>
-              <span class="truncate"><%= task.name %></span>
-              <span class="shrink-0 text-content-muted"><%= state["source_state"] %></span>
-            <% end %>
+    <details class="border-b border-border xl:border-b-0 xl:border-r">
+      <summary class="flex min-h-12 cursor-pointer list-none items-center justify-between px-4 py-2 text-xs font-semibold text-content">
+        Work by project <span class="font-normal text-content-muted"><%= @project_work_counts.length %></span>
+      </summary>
+      <div class="max-h-52 overflow-y-auto border-t border-border p-3"
+           data-board-section="project-work-summary"
+           data-source-count="<%= @project_work_counts.length %>"
+           data-rendered-count="<%= @project_work_counts.length %>">
+        <div class="flex flex-wrap gap-2">
+          <% @project_work_counts.each do |project, counts| %>
+            <% details = counts.filter_map { |lane_name, count| "#{count} #{lane_name}" if count.positive? } %>
+            <span class="rounded-md border border-border bg-bg-elevated px-2 py-1 text-xs text-content">
+              <strong><%= project %></strong>: <%= details.join(" · ") %>
+            </span>
           <% end %>
-          <% if @recent.empty? %>
-            <p class="px-2 py-3 text-content-muted">No completed work yet.</p>
+          <% if @project_work_counts.empty? %>
+            <span class="text-content-muted">No open work is mirrored.</span>
           <% end %>
         </div>
-      </details>
+      </div>
+    </details>
 
-      <%= render "request_status" %>
-    </div>
+    <details class="border-b border-border sm:border-r xl:border-b-0"
+             data-board-section="recently-completed"
+             data-source-count="<%= @recent.length %>"
+             data-rendered-count="<%= [@recent.length, 20].min %>">
+      <summary class="flex min-h-12 cursor-pointer list-none items-center justify-between px-4 py-2 text-xs font-semibold text-content">
+        Recently completed <span class="font-normal text-content-muted"><%= @recent.length > 20 ? "20 of #{@recent.length}" : @recent.length %></span>
+      </summary>
+      <div class="max-h-52 space-y-1 overflow-y-auto border-t border-border p-2">
+        <% @recent.first(20).each do |task| %>
+          <% state = task.state_data.fetch("orchestration", {}) %>
+          <%= link_to control_room_path(task_id: task.id, lane: active_lane),
+                class: "flex items-center justify-between gap-2 rounded-md px-2 py-2 text-xs text-content-secondary hover:bg-bg-elevated",
+                data: { task_origin_id: task.origin_session_id } do %>
+            <span class="truncate"><%= task.name %></span>
+            <span class="shrink-0 text-content-muted"><%= state["source_state"] %></span>
+          <% end %>
+        <% end %>
+        <% if @recent.empty? %>
+          <p class="px-2 py-3 text-content-muted">No completed work yet.</p>
+        <% end %>
+      </div>
+    </details>
+
+    <%= render "request_status" %>
   </footer>
 </section>

--- a/app/views/control_room/_task_list.html.erb
+++ b/app/views/control_room/_task_list.html.erb
@@ -1,53 +1,84 @@
-<section class="h-full min-h-0 <%= "hidden" unless active %>"
-         data-board-section="<%= title.parameterize %>"
+<% tone = {
+     "waiting" => "border-yellow-400/35 text-yellow-200",
+     "running" => "border-green-400/35 text-green-300",
+     "queued" => "border-sky-400/30 text-sky-300",
+     "parked" => "border-slate-400/25 text-slate-300"
+   }.fetch(lane) %>
+<section class="flex min-h-64 flex-col overflow-hidden rounded-lg border border-border bg-bg-base/20 xl:min-h-0"
+         data-board-section="<%= definition[:section] %>"
          data-source-count="<%= tasks.length %>"
          data-rendered-count="<%= [tasks.length, 50].min %>"
          data-workspace-panel="<%= lane %>">
-  <div class="grid grid-cols-[minmax(0,1fr)_7rem_4.5rem] gap-3 border-b border-border bg-bg-base/20 px-4 py-2 text-[11px] font-semibold uppercase tracking-wider text-content-muted">
-    <span>Project · work</span>
-    <span>Status</span>
-    <span class="text-right">Updated</span>
-  </div>
-  <div class="h-[calc(100%-2.25rem)] overflow-y-auto">
+  <header class="shrink-0 border-b border-border px-3 py-2.5">
+    <div class="flex items-center justify-between gap-2">
+      <h2 class="font-semibold text-content"><%= definition[:title] %></h2>
+      <span class="min-w-7 rounded-md bg-bg-elevated px-2 py-0.5 text-center text-xs font-semibold tabular-nums <%= tone %>">
+        <%= tasks.length %>
+      </span>
+    </div>
+    <p class="mt-0.5 text-[11px] leading-snug text-content-muted"><%= definition[:description] %></p>
+  </header>
+
+  <div class="min-h-0 flex-1 overflow-y-auto">
     <% tasks.first(50).each do |task| %>
       <% state = task.state_data.fetch("orchestration", {}) %>
       <% selected = @selected_task&.id == task.id %>
-      <% tone = case lane
-           when "waiting" then "text-yellow-300"
-           when "running" then "text-green-300"
-           when "queued" then "text-sky-300"
-           else "text-violet-300"
-           end %>
       <%= link_to control_room_path(task_id: task.id, lane: lane),
-            class: "grid min-h-[4.5rem] grid-cols-[minmax(0,1fr)_7rem_4.5rem] items-center gap-3 border-b border-border px-4 py-3 transition-colors hover:bg-bg-elevated/70 #{selected ? "bg-accent/10 shadow-[inset_3px_0_0_var(--color-accent)]" : ""}",
+            class: "block border-b border-border px-3 py-2.5 transition-colors hover:bg-bg-elevated/70 #{selected ? "bg-accent/10 shadow-[inset_3px_0_0_var(--color-accent)]" : ""}",
             aria: { current: selected ? "true" : nil },
             data: { task_origin_id: task.origin_session_id } do %>
-        <span class="min-w-0">
-          <span class="block truncate text-xs font-semibold uppercase tracking-wide text-accent"><%= state["project"].presence || "Unassigned" %></span>
-          <span class="mt-1 block truncate text-sm font-medium text-content"><%= task.name %></span>
-          <% if lane == "waiting" && state["blocker"].present? %>
-            <span class="mt-1 block truncate text-xs text-content-muted"><%= state["blocker"] %></span>
-          <% end %>
+        <span class="flex items-start justify-between gap-2">
+          <span class="min-w-0">
+            <span class="flex flex-wrap items-center gap-1.5">
+              <span class="text-[10px] font-semibold uppercase tracking-wide text-accent"><%= state["project"].presence || "Unassigned" %></span>
+              <% if program_task?(task) %>
+                <span class="rounded border border-violet-400/25 bg-violet-400/10 px-1 py-0.5 text-[9px] font-semibold uppercase text-violet-200">
+                  Program
+                </span>
+              <% end %>
+              <% if stale_blocker?(task) %>
+                <span class="rounded border border-yellow-400/30 bg-yellow-400/10 px-1 py-0.5 text-[9px] font-semibold uppercase text-yellow-200">
+                  stale blocker
+                </span>
+              <% end %>
+            </span>
+            <span class="mt-1 block line-clamp-2 text-sm font-medium leading-snug text-content"><%= task.name %></span>
+          </span>
+          <time class="shrink-0 text-[10px] tabular-nums text-content-muted"
+                datetime="<%= task.updated_at.iso8601 %>"><%= time_ago_in_words(task.updated_at) %></time>
         </span>
-        <span class="inline-flex items-center gap-2 text-xs font-semibold uppercase <%= tone %>">
-          <span class="size-2 rounded-full bg-current <%= "animate-pulse" if lane == "running" %>" aria-hidden="true"></span>
-          <%= { "waiting" => "Needs you", "running" => "Working", "queued" => "Scheduled", "program" => "Program" }.fetch(lane) %>
+        <% if %w[waiting parked].include?(lane) && state["blocker"].present? %>
+          <span class="mt-1.5 block line-clamp-2 text-xs leading-snug text-content-muted"><%= state["blocker"] %></span>
+        <% elsif lane == "queued" %>
+          <span class="mt-1.5 block text-xs text-content-muted"><%= state["source_state"] == "ready" ? "Ready to dispatch" : "Waiting in the ledger queue" %></span>
+        <% end %>
+        <span class="mt-2 inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase <%= tone %>">
+          <span class="size-1.5 rounded-full bg-current <%= "animate-pulse motion-reduce:animate-none" if lane == "running" %>" aria-hidden="true"></span>
+          <%= {
+                "waiting" => "Decision",
+                "running" => "Running",
+                "queued" => state["source_state"].presence || "Queued",
+                "parked" => stale_blocker?(task) ? "Review stale blocker" : state["source_state"].presence || "Paused"
+              }.fetch(lane) %>
         </span>
-        <time class="text-right text-xs tabular-nums text-content-muted"
-              datetime="<%= task.updated_at.iso8601 %>"><%= time_ago_in_words(task.updated_at) %></time>
       <% end %>
     <% end %>
+
     <% if tasks.empty? %>
-      <div class="flex h-full min-h-56 flex-col items-center justify-center px-6 text-center">
-        <span class="flex size-12 items-center justify-center rounded-full border border-border bg-bg-elevated text-content-muted">
-          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="size-5" stroke="currentColor" stroke-width="1.8">
+      <div class="flex min-h-40 flex-1 flex-col items-center justify-center px-4 text-center">
+        <span class="flex size-10 items-center justify-center rounded-full border border-border bg-bg-elevated text-content-muted">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="size-4" stroke="currentColor" stroke-width="1.8">
             <path stroke-linecap="round" stroke-linejoin="round" d="m5 12 4 4L19 6"/>
           </svg>
         </span>
-        <p class="mt-3 font-semibold text-content">
-          <%= { "waiting" => "Nothing needs you", "running" => "No work is running", "queued" => "Nothing is scheduled", "program" => "No programs are active" }.fetch(lane) %>
+        <p class="mt-2 text-sm font-semibold text-content">
+          <%= {
+                "waiting" => "Nothing needs you",
+                "running" => "No ledger task is running",
+                "queued" => "The queue is empty",
+                "parked" => "Nothing is paused"
+              }.fetch(lane) %>
         </p>
-        <p class="mt-1 text-xs text-content-muted">The count above is sourced directly from the mirrored ledger.</p>
       </div>
     <% end %>
   </div>

--- a/app/views/control_room/show.html.erb
+++ b/app/views/control_room/show.html.erb
@@ -15,143 +15,20 @@
         </div>
         <div class="min-w-0">
           <h1 class="truncate text-xl font-semibold text-content font-display">Control Room</h1>
-          <p class="truncate text-xs text-content-muted">One place to decide, reply, and see what moves next.</p>
+          <p class="truncate text-xs text-content-muted">Decide what needs you. See what is actually moving.</p>
         </div>
       </div>
       <%= render "source_health" %>
     </header>
 
     <%= render "fleet" %>
+    <%= render "composer_bar" %>
 
-    <div class="grid min-h-0 flex-1 lg:grid-cols-[minmax(32rem,1.08fr)_minmax(28rem,0.92fr)]">
-      <main class="flex min-h-[32rem] flex-col border-b border-border lg:min-h-0 lg:border-b-0 lg:border-r">
+    <div class="grid min-h-0 flex-1 <%= @selected_task ? "lg:grid-cols-[minmax(0,1fr)_minmax(22rem,28rem)]" : "grid-cols-1" %>">
+      <main class="flex min-h-[32rem] flex-col lg:min-h-0">
         <%= render "task_board" %>
       </main>
-
-      <aside id="task-thread"
-             class="flex min-h-[34rem] flex-col bg-bg-base/30"
-             role="complementary"
-             data-persistent-drawer="true"
-             aria-labelledby="task-thread-title">
-        <% if @selected_task %>
-          <% state = @selected_task.state_data.fetch("orchestration", {}) %>
-          <header class="shrink-0 border-b border-border px-5 py-4">
-            <div class="flex items-start justify-between gap-3">
-              <div class="min-w-0">
-                <p class="text-xs font-semibold uppercase tracking-[0.14em] text-accent"><%= state["project"] %></p>
-                <h2 id="task-thread-title" class="mt-1 text-xl font-semibold leading-tight text-content">
-                  <%= @selected_task.name %>
-                </h2>
-              </div>
-              <%= link_to control_room_path(lane: active_lane),
-                    class: "flex size-11 shrink-0 items-center justify-center rounded-lg border border-border text-content-muted transition-colors hover:border-accent/40 hover:text-content",
-                    aria: { label: "Close task detail" } do %>
-                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" class="size-5" stroke="currentColor" stroke-width="1.8">
-                  <path stroke-linecap="round" d="m7 7 10 10M17 7 7 17"/>
-                </svg>
-              <% end %>
-            </div>
-          </header>
-
-          <%= render "selected_task_summary" %>
-
-          <div class="shrink-0 border-t border-border bg-bg-surface px-5 py-4">
-            <%= form_with url: control_room_task_messages_path(@selected_task),
-                  class: "space-y-3" do |form| %>
-              <%= form.hidden_field :lane, value: active_lane %>
-              <%= form.label :content, "Reply to pane 0", class: "block text-xs font-semibold text-content-secondary" %>
-              <%= form.text_area :content, required: true, rows: 3, placeholder: "Type your direction or answer…",
-                    class: "w-full resize-none rounded-lg border border-border bg-bg-elevated px-3 py-3 text-base text-content placeholder:text-content-muted focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" %>
-              <%= form.submit "Reply", class: "min-h-11 cursor-pointer rounded-lg bg-accent px-5 py-2.5 font-semibold text-white transition-colors hover:bg-accent-hover" %>
-            <% end %>
-            <div class="mt-3 flex flex-wrap items-center gap-2">
-              <% if task_needs_attention?(@selected_task) || state["source_state"] == "review" %>
-                <%= button_to "Approve", approve_control_room_task_path(@selected_task),
-                      params: { lane: active_lane },
-                      class: "min-h-11 rounded-lg border border-green-500/40 px-4 py-2.5 font-semibold text-green-300 hover:bg-green-500/10" %>
-              <% end %>
-              <% if state["source_state"] == "failed" %>
-                <%= button_to "Retry", retry_control_room_task_path(@selected_task),
-                      params: { lane: active_lane },
-                      class: "min-h-11 rounded-lg border border-sky-500/40 px-4 py-2.5 font-semibold text-sky-300 hover:bg-sky-500/10" %>
-              <% end %>
-              <%= link_to "Open full task", board_task_path(@selected_task.board, @selected_task),
-                    data: { turbo_frame: "task_panel" },
-                    class: "inline-flex min-h-11 items-center rounded-lg border border-border px-4 py-2.5 font-semibold text-content-secondary hover:border-accent/40 hover:text-content" %>
-              <% unless %w[done cancelled].include?(state["source_state"]) %>
-                <%= button_to "Cancel", cancel_control_room_task_path(@selected_task),
-                      params: { lane: active_lane },
-                      class: "ml-auto min-h-11 rounded-lg px-3 py-2.5 font-semibold text-red-400 hover:bg-red-500/10" %>
-              <% end %>
-            </div>
-          </div>
-        <% else %>
-          <header class="shrink-0 border-b border-border px-5 py-4">
-            <p class="text-xs font-semibold uppercase tracking-[0.14em] text-accent">Orchestrator</p>
-            <h2 id="task-thread-title" class="mt-1 text-xl font-semibold text-content">Ask pane 0</h2>
-            <p class="mt-1 text-sm text-content-muted">Ask about one project or request a fleet-wide assessment.</p>
-          </header>
-
-          <div class="min-h-0 flex-1 overflow-y-auto p-5">
-            <%= form_with url: control_room_ask_path, class: "space-y-4" do |form| %>
-              <%= form.hidden_field :source_id, value: @source&.id, id: "question_source_id" %>
-              <div>
-                <%= form.label :project, "Question context", for: "question_project", class: "mb-1.5 block text-xs font-medium text-content-secondary" %>
-                <%= form.select :project, @question_options, { include_blank: false },
-                      id: "question_project",
-                      class: "min-h-11 w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-              </div>
-              <div>
-                <%= form.label :title, "Question title", for: "question_title", class: "mb-1.5 block text-xs font-medium text-content-secondary" %>
-                <%= form.text_field :title, id: "question_title", placeholder: "What is this about?",
-                      class: "min-h-11 w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-              </div>
-              <div>
-                <%= form.label :brief, "Question", for: "question_brief", class: "mb-1.5 block text-xs font-medium text-content-secondary" %>
-                <%= form.text_area :brief, id: "question_brief", required: true, rows: 6,
-                      placeholder: "What do you want pane 0 to assess, explain, or decide?",
-                      class: "w-full resize-none rounded-lg border border-border bg-bg-elevated px-3 py-3 text-base text-content" %>
-              </div>
-              <%= form.submit "Ask pane 0", disabled: @source.blank?,
-                    class: "min-h-11 w-full cursor-pointer rounded-lg bg-accent px-4 py-2.5 font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40" %>
-            <% end %>
-
-            <details class="mt-5 rounded-lg border border-border bg-bg-surface">
-              <summary class="flex min-h-11 cursor-pointer list-none items-center justify-between px-4 py-3">
-                <span class="font-semibold text-content">Create new work</span>
-                <span class="text-xs text-content-muted">expand</span>
-              </summary>
-              <div class="border-t border-border p-4">
-                <%= form_with url: control_room_tasks_path, class: "grid gap-3" do |form| %>
-                  <%= form.hidden_field :source_id, value: @source&.id, id: "task_source_id" %>
-                  <%= form.label :project, "Work context", for: "task_project", class: "sr-only" %>
-                  <%= form.select :project, @project_options, { prompt: "Choose a live pane / project" },
-                        id: "task_project", required: true,
-                        class: "min-h-11 w-full rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-                  <%= form.label :title, "Task title", for: "task_title", class: "sr-only" %>
-                  <%= form.text_field :title, id: "task_title", placeholder: "Task title",
-                        class: "min-h-11 rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-                  <%= form.label :brief, "Task brief", for: "task_brief", class: "sr-only" %>
-                  <%= form.text_area :brief, id: "task_brief", required: true, rows: 3, placeholder: "What should be done?",
-                        class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-                  <%= form.label :acceptance, "Acceptance criteria", for: "task_acceptance", class: "sr-only" %>
-                  <%= form.text_area :acceptance, id: "task_acceptance", rows: 2, placeholder: "What does done look like?",
-                        class: "rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-                  <div class="flex items-center justify-between gap-3">
-                    <%= form.label :priority, "Priority", for: "task_priority", class: "sr-only" %>
-                    <%= form.select :priority, [["Normal", "normal"], ["High", "high"], ["Low", "low"]], {},
-                          id: "task_priority",
-                          class: "min-h-11 rounded-lg border border-border bg-bg-elevated px-3 py-2 text-content" %>
-                    <%= form.submit "Create task", disabled: @source.blank?,
-                          class: "min-h-11 cursor-pointer rounded-lg bg-accent px-4 py-2 font-semibold text-white disabled:opacity-40" %>
-                  </div>
-                <% end %>
-              </div>
-            </details>
-          </div>
-        <% end %>
-      </aside>
+      <%= render "selected_task_drawer" if @selected_task %>
     </div>
   </div>
-  <%= turbo_frame_tag "task_panel" %>
 </div>

--- a/test/controllers/control_room_controller_test.rb
+++ b/test/controllers/control_room_controller_test.rb
@@ -334,7 +334,8 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     assert_select "details:not([open]) summary", text: /Create work/
     assert_select "aside#task-thread[data-persistent-drawer='true']", count: 1
     assert_select "[data-control-room-live-region='selected-task-summary']", text: /The canary passed/
-    assert_select "#task-thread textarea[placeholder='Type your decision or answer…']", count: 1
+    assert_select "#task-thread", text: /Send optional direction/
+    assert_select "#task-thread textarea[placeholder='Add context or change direction…']", count: 1
     assert_select "#task-thread a", text: "Open full task", count: 1
   end
 

--- a/test/controllers/control_room_controller_test.rb
+++ b/test/controllers/control_room_controller_test.rb
@@ -82,12 +82,12 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-control-room-live-region='fleet'][data-source-count='3'][data-rendered-count='3']"
     assert_select "[data-pane-status='working']", count: 1
     assert_select "[data-pane-status='idle']", count: 1
-    assert_select "[data-pane-status='present']", count: 1
+    assert_select "[data-pane-status='not-reporting']", count: 1
     assert_select "aside#task-thread[role='complementary'][data-persistent-drawer='true']", count: 1
     assert_select "#task-thread[aria-modal]", count: 0
-    assert_select "#task-thread a[href='#{board_task_path(task.board, task)}'][data-turbo-frame='task_panel']",
+    assert_select "#task-thread a[href='#{board_task_path(task.board, task)}'][data-turbo-frame='_top']",
       text: "Open full task"
-    assert_select "turbo-frame#task_panel", count: 1
+    assert_select "turbo-frame#task_panel", count: 0
     assert_select "#task-thread [data-task-context='full']", count: 0
     assert_select "#task-thread #task-thread-messages", count: 0
     projected_link = css_select("[data-task-origin-id='#{task.origin_session_id}']").sole
@@ -102,7 +102,7 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
       assert_equal "_fleet", select.first.css("option").first["value"]
     end
     assert_select "option[value='whatsappbot']", text: /pane 5/, count: 2
-    assert_select "option[value='omniremote']", text: /present/, count: 2
+    assert_select "option[value='omniremote']", text: /not-reporting/, count: 2
 
     other = Task.create!(user: users(:two), board: boards(:two), name: "Other",
       origin_session_key: "wezbridge:primary:task:T-OTHER")
@@ -133,7 +133,7 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     get control_room_live_path(source_id: @source.id)
 
     assert_response :success
-    assert_select "[data-control-room-live-region]", count: 4
+    assert_select "[data-control-room-live-region]", count: 5
     assert_select "[data-control-room-live-region='requests'][data-source-count='2'][data-rendered-count='2']",
       text: /##{applied.id} Message/
     assert_includes response.body, "Delivered to the ledger"
@@ -196,7 +196,7 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     waiting = projected_task_with(id: "T-0101", name: "Needs a reply", state: "review")
     running = projected_task_with(id: "T-0102", name: "Executing now", state: "running")
     queued = projected_task_with(id: "T-0103", name: "Starts next", state: "ready")
-    program = projected_task_with(
+    queued_program = projected_task_with(
       id: "T-0104",
       name: "Long-running quality loop",
       state: "queued",
@@ -210,6 +210,11 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
       work_type: "program",
       project: "mutual"
     )
+    parked = projected_task_with(
+      id: "T-0108",
+      name: "Dependency is blocked",
+      state: "blocked"
+    )
     completed = projected_task_with(
       id: "T-0106",
       name: "Finished",
@@ -219,7 +224,7 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     unclassified = projected_task_with(
       id: "T-0107",
       name: "Unknown source state",
-      state: "paused"
+      state: "mystery"
     )
     sign_in_as(@user)
 
@@ -228,9 +233,9 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     expected = {
       "needs-you" => [waiting],
-      "in-progress" => [running],
-      "scheduled" => [queued],
-      "programs" => [program, explicit_program],
+      "running-now" => [running, explicit_program],
+      "queue" => [queued, queued_program],
+      "paused" => [parked],
       "unclassified" => [unclassified],
       "recently-completed" => [completed]
     }
@@ -245,7 +250,7 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     assert_equal rendered_ids.uniq.sort, rendered_ids.sort, "a task must render in one lane only"
 
     board = css_select("[data-control-room-live-region='task-board']").sole
-    assert_equal "6", board["data-open-source-count"]
+    assert_equal "7", board["data-open-source-count"]
     assert_equal "1", board["data-unclassified-count"]
     assert_includes css_select("[data-board-section='unclassified']").sole.text,
       "classification gap, not work you owe"
@@ -253,9 +258,15 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     assert_equal "2", summary["data-source-count"]
     assert_equal "2", summary["data-rendered-count"]
     assert_includes summary.text,
-      "whatsappbot: 1 waiting · 1 running · 1 queued · 1 program · 1 unclassified"
-    assert_includes summary.text, "mutual: 1 program"
+      "whatsappbot: 1 waiting · 1 running · 2 queued · 1 parked · 1 unclassified · 1 programs"
+    assert_includes summary.text, "mutual: 1 running · 1 programs"
     assert_includes summary.text, "1 unclassified"
+
+    programs = css_select("[data-board-section='programs']").sole
+    assert_equal "2", programs["data-source-count"]
+    assert_equal "2", programs["data-rendered-count"]
+    assert_equal [queued_program.origin_session_id, explicit_program.origin_session_id].sort,
+      programs.css("[data-task-origin-id]").map { |card| card["data-task-origin-id"] }.sort
   end
 
   test "renders a loud stalled bridge warning with its error" do
@@ -303,7 +314,7 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test "renders a focus inbox with persistent detail and latest pane reply" do
+  test "renders a one-glance cockpit with collapsed composers and persistent detail" do
     task = projected_task
     task.agent_messages.create!(
       direction: "incoming",
@@ -316,13 +327,45 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
     get control_room_path(task_id: task.id)
 
     assert_response :success
-    assert_select "nav[aria-label='Work status'] [aria-current='page']", text: /Needs you/
-    assert_select "[data-workspace-panel='waiting']:not(.hidden)", count: 1
-    assert_select "[data-workspace-panel='running'].hidden", count: 1
+    assert_select "[data-workspace-panel]", count: 4
+    assert_select "[data-workspace-panel='waiting']", count: 1
+    assert_select "[data-workspace-panel='running']", count: 1
+    assert_select "details:not([open]) summary", text: /Ask pane 0/
+    assert_select "details:not([open]) summary", text: /Create work/
     assert_select "aside#task-thread[data-persistent-drawer='true']", count: 1
     assert_select "[data-control-room-live-region='selected-task-summary']", text: /The canary passed/
-    assert_select "#task-thread textarea[placeholder='Type your direction or answer…']", count: 1
+    assert_select "#task-thread textarea[placeholder='Type your decision or answer…']", count: 1
     assert_select "#task-thread a", text: "Open full task", count: 1
+  end
+
+  test "keeps non-operator blockers out of needs you and flags completed dependencies" do
+    dependency = projected_task_with(
+      id: "T-0200",
+      name: "Dependency completed",
+      state: "done",
+      status: :done
+    )
+    blocked = projected_task_with(
+      id: "T-0201",
+      name: "Blocked by completed dependency",
+      state: "blocked",
+      blocker: "#{dependency.origin_session_id} must finish first",
+      contract: { "mode" => "born_blocked", "gate" => "operator" }
+    )
+    sign_in_as(@user)
+
+    get control_room_path(task_id: blocked.id, lane: "parked")
+
+    assert_response :success
+    assert_equal 0, css_select("[data-board-section='needs-you'] [data-task-origin-id='T-0201']").count
+    paused = css_select("[data-board-section='paused']").sole
+    assert_equal 1, paused.css("[data-task-origin-id='T-0201']").count
+    assert_includes paused.text, "stale blocker"
+    assert_select "#task-thread", text: /does not need a new operator decision/
+    assert_select "#task-thread", text: /Send optional direction/
+    assert_select "#task-thread", text: /Answer pane 0/, count: 0
+    assert_select "#task-thread form[action='#{approve_control_room_task_path(blocked)}']", count: 0
+    assert_select "#task-thread form[action='#{retry_control_room_task_path(blocked)}']", count: 1
   end
 
   private
@@ -348,7 +391,7 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
 
   def projected_task_with(
     id:, name:, state:, kind: "task", status: :up_next, needs_decision: false,
-    project: "whatsappbot", work_type: nil
+    project: "whatsappbot", work_type: nil, blocker: nil, contract: nil
   )
     @user.tasks.create!(
       board: boards(:one),
@@ -364,7 +407,9 @@ class ControlRoomControllerTest < ActionDispatch::IntegrationTest
           "source_state" => state,
           "project" => project,
           "kind" => kind,
-          "work_type" => work_type
+          "work_type" => work_type,
+          "blocker" => blocker,
+          "contract" => contract
         }
       }
     )

--- a/test/system/control_room_test.rb
+++ b/test/system/control_room_test.rb
@@ -43,12 +43,12 @@ class ControlRoomTest < ApplicationSystemTestCase
     within("[data-board-section='needs-you']") do
       assert_text "Operator ruling required before execution."
     end
-    find("summary", text: "Create new work").click
+    find("summary", text: "Create work").click
     within("form[action='#{control_room_tasks_path}']") do
-      select "pane 0 — wezbridge (idle)", from: "Work context"
-      fill_in "title", with: "Ship a focused fix"
-      fill_in "brief", with: "Implement and verify the requested change."
-      click_button "Create task"
+      select "pane 0 — wezbridge (idle)", from: "Project"
+      fill_in "Title", with: "Ship a focused fix"
+      fill_in "Brief", with: "Implement and verify the requested change."
+      click_button "Create"
     end
 
     assert_text "Task queued as intent"
@@ -67,11 +67,12 @@ class ControlRoomTest < ApplicationSystemTestCase
   test "asks pane 0 for a fleet assessment without choosing one project" do
     visit control_room_path
 
+    find("summary", text: "Ask pane 0").click
     within("form[action='#{control_room_ask_path}']") do
-      assert_equal "_fleet", find_field("Question context").value
-      fill_in "Question title", with: "Assess every open pane"
+      assert_equal "_fleet", find_field("Context").value
+      fill_in "Subject", with: "Assess every open pane"
       fill_in "Question", with: "Recommend the next action for every live project."
-      click_button "Ask pane 0"
+      click_button "Ask"
     end
 
     assert_text "Question queued as intent"
@@ -80,26 +81,21 @@ class ControlRoomTest < ApplicationSystemTestCase
     assert_equal "question", intent.payload["kind"]
   end
 
-  test "opens the existing full task panel from the quick reply drawer" do
+  test "opens the existing full task page from the quick reply drawer" do
     visit control_room_path(task_id: @task.id)
 
     within("#task-thread") { click_link "Open full task" }
 
-    if ApplicationSystemTestCase::CHROME_AVAILABLE
-      assert_selector "[data-controller~='task-modal']", wait: 8
-      assert_text "Review the canary"
-    else
-      assert_current_path board_task_path(@task.board, @task)
-      assert_text "Confirm the live evidence."
-    end
+    assert_current_path board_task_path(@task.board, @task)
+    assert_text "Confirm the live evidence."
   end
 
   test "refreshes cockpit state without clearing a draft" do
     skip "Requires JavaScript support" unless ApplicationSystemTestCase::CHROME_AVAILABLE
 
     visit control_room_path
-    find("summary", text: "Create new work").click
-    fill_in "Task title", with: "Keep this draft"
+    find("summary", text: "Create work").click
+    fill_in "task_title", with: "Keep this draft"
 
     @user.tasks.create!(
       board: boards(:one),
@@ -119,11 +115,11 @@ class ControlRoomTest < ApplicationSystemTestCase
 
     assert_selector "[data-workspace-panel='running']",
       text: "Appeared without a reload", visible: :all, wait: 8
-    assert_field "Task title", with: "Keep this draft"
+    assert_field "task_title", with: "Keep this draft"
     assert_text "Live cockpit · updated just now"
   end
 
-  test "switches work lanes and keeps the selected detail beside the list" do
+  test "shows work lanes together and keeps selected detail beside the list" do
     @user.tasks.create!(
       board: boards(:one),
       name: "Running live verification",
@@ -141,12 +137,13 @@ class ControlRoomTest < ApplicationSystemTestCase
     )
 
     visit control_room_path
-    click_link "In progress"
-
-    assert_selector "[data-workspace-panel='running']:not(.hidden)"
+    assert_selector "[data-workspace-panel='waiting']"
+    assert_selector "[data-workspace-panel='running']"
+    assert_selector "[data-workspace-panel='queued']"
+    assert_selector "[data-workspace-panel='parked']"
     click_link "Running live verification"
     assert_selector "#task-thread[data-persistent-drawer='true']"
     assert_text "Running live verification"
-    assert_selector "[data-workspace-panel='running']:not(.hidden)"
+    assert_selector "[data-workspace-panel='running']"
   end
 end


### PR DESCRIPTION
## Outcome
Turns Control Room into a one-glance cockpit instead of a composer-first page.

- Shows Needs you, Running now, Queue, and Paused together.
- Treats Programs as a cross-cutting work type, never as a runtime lane.
- Separates busy panes from running ledger tasks in plain language.
- Collapses Ask pane 0 and Create work to one-action composers.
- Renames unknown/present pane status to not reporting.
- Keeps source/render counts and the unclassified strip.
- Moves historical/project/program/receipt details into compact progressive disclosure.
- Makes stale completed-dependency blockers paused/requeueable instead of fake operator alarms.

## Quick drawer ownership boundary
The Control Room drawer may contain only status/blocker, next action, reply or optional direction, approve/retry/requeue/cancel, and Open full task. It must never gain diffs, artifacts, dependencies, run history, or full agent output. Those belong to the existing Boards task page.

## Verification
- `git diff --check`: clean
- Local Rails execution: unavailable in this Windows checkout; no local app/container was launched.
- Hosted CI and security checks are the executable gate before merge.
- After merge: guarded exact-SHA deploy, running-app SHA readback, then live Chrome screenshots at desktop and narrow widths with composer/work pixel measurements.

## Tracking
- Ledger: T-0040
- Bead: claw-qxx